### PR TITLE
feat: Componentes UI base (Button, Card, Badge) - Fase 1#9

### DIFF
--- a/src/components/UIDemo.tsx
+++ b/src/components/UIDemo.tsx
@@ -1,0 +1,105 @@
+import { Button, Card, Badge } from '@/components/ui';
+import { Upload, Download, Settings } from 'lucide-react';
+
+/**
+ * Componente de demostración para probar los componentes UI base
+ * Este componente es temporal y se usará para verificar que todo funciona
+ */
+export const UIDemo = () => {
+  return (
+    <div className="container mx-auto px-4 py-12 space-y-8">
+      <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+        Demo Componentes UI
+      </h2>
+
+      {/* Buttons Demo */}
+      <Card title="Botones" description="Diferentes variantes y tamaños">
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-3">
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+          </div>
+          
+          <div className="flex flex-wrap gap-3 items-center">
+            <Button size="sm">Small</Button>
+            <Button size="md">Medium</Button>
+            <Button size="lg">Large</Button>
+          </div>
+          
+          <div className="flex flex-wrap gap-3">
+            <Button icon={<Upload size={16} />}>
+              Con ícono izquierdo
+            </Button>
+            <Button icon={<Download size={16} />} iconPosition="right">
+              Con ícono derecho
+            </Button>
+          </div>
+          
+          <div className="flex flex-wrap gap-3">
+            <Button loading>Cargando...</Button>
+            <Button disabled>Deshabilitado</Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* Badges Demo */}
+      <Card title="Badges" description="Etiquetas con diferentes variantes">
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="default">Default</Badge>
+          <Badge variant="info">JPG</Badge>
+          <Badge variant="success">PNG</Badge>
+          <Badge variant="warning">WebP</Badge>
+          <Badge variant="error">Error</Badge>
+        </div>
+        
+        <div className="flex flex-wrap gap-2 mt-4">
+          <Badge size="sm" variant="info">Small</Badge>
+          <Badge size="md" variant="success">Medium</Badge>
+        </div>
+      </Card>
+
+      {/* Cards Demo */}
+      <Card title="Cards Anidados" description="Ejemplo de cards con diferentes configuraciones">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card variant="border" padding="sm">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Card con borde y padding pequeño
+            </p>
+          </Card>
+          
+          <Card variant="shadow" padding="lg">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Card con sombra y padding grande
+            </p>
+          </Card>
+        </div>
+      </Card>
+
+      {/* Interactive Example */}
+      <Card 
+        title="Ejemplo Interactivo" 
+        description="Simula una acción de compresión"
+        padding="lg"
+      >
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex gap-2">
+            <Badge variant="info">JPG</Badge>
+            <Badge variant="warning">2.5 MB</Badge>
+          </div>
+          
+          <Button 
+            icon={<Settings size={18} />}
+            onClick={() => alert('¡Componentes UI funcionando correctamente!')}
+          >
+            Probar Componente
+          </Button>
+          
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Haz clic en el botón para verificar que los eventos funcionan
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,91 @@
+import type { FC, HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+export type BadgeVariant = 'info' | 'success' | 'warning' | 'error' | 'default';
+export type BadgeSize = 'sm' | 'md';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Variante de color del badge
+   * @default 'default'
+   */
+  variant?: BadgeVariant;
+  
+  /**
+   * Tamaño del badge
+   * @default 'md'
+   */
+  size?: BadgeSize;
+  
+  /**
+   * Contenido del badge (texto o elementos)
+   */
+  children: React.ReactNode;
+}
+
+/**
+ * Componente Badge para etiquetas y tags pequeños
+ * Útil para formatos de archivo, estados, etc.
+ * 
+ * @example
+ * ```tsx
+ * <Badge variant="info">JPG</Badge>
+ * <Badge variant="success" size="sm">Comprimido</Badge>
+ * <Badge variant="warning">10 MB</Badge>
+ * ```
+ */
+export const Badge: FC<BadgeProps> = ({
+  variant = 'default',
+  size = 'md',
+  children,
+  className,
+  ...props
+}) => {
+  const baseStyles = cn(
+    'inline-flex items-center justify-center',
+    'font-medium rounded-full',
+    'transition-colors'
+  );
+
+  const variantStyles = {
+    default: cn(
+      'bg-gray-100 text-gray-800',
+      'dark:bg-gray-700 dark:text-gray-300'
+    ),
+    info: cn(
+      'bg-blue-100 text-blue-800',
+      'dark:bg-blue-900/30 dark:text-blue-400'
+    ),
+    success: cn(
+      'bg-green-100 text-green-800',
+      'dark:bg-green-900/30 dark:text-green-400'
+    ),
+    warning: cn(
+      'bg-yellow-100 text-yellow-800',
+      'dark:bg-yellow-900/30 dark:text-yellow-400'
+    ),
+    error: cn(
+      'bg-red-100 text-red-800',
+      'dark:bg-red-900/30 dark:text-red-400'
+    ),
+  };
+
+  const sizeStyles = {
+    sm: 'px-2 py-0.5 text-xs',
+    md: 'px-2.5 py-1 text-sm',
+  };
+
+  return (
+    <span
+      className={cn(
+        baseStyles,
+        variantStyles[variant],
+        sizeStyles[size],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,149 @@
+import type { FC, ButtonHTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Variante visual del botón
+   * @default 'primary'
+   */
+  variant?: ButtonVariant;
+  
+  /**
+   * Tamaño del botón
+   * @default 'md'
+   */
+  size?: ButtonSize;
+  
+  /**
+   * Estado de carga (muestra spinner y deshabilita)
+   */
+  loading?: boolean;
+  
+  /**
+   * Contenido del botón
+   */
+  children: ReactNode;
+  
+  /**
+   * Ícono opcional (componente de lucide-react)
+   */
+  icon?: ReactNode;
+  
+  /**
+   * Posición del ícono
+   * @default 'left'
+   */
+  iconPosition?: 'left' | 'right';
+}
+
+/**
+ * Componente Button reutilizable con variantes de estilo
+ * 
+ * @example
+ * ```tsx
+ * <Button variant="primary" size="md" onClick={handleClick}>
+ *   Comprimir
+ * </Button>
+ * 
+ * <Button variant="secondary" icon={<Upload />}>
+ *   Subir archivos
+ * </Button>
+ * ```
+ */
+export const Button: FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  children,
+  icon,
+  iconPosition = 'left',
+  className,
+  disabled,
+  ...props
+}) => {
+  const baseStyles = cn(
+    'inline-flex items-center justify-center gap-2',
+    'font-medium rounded-lg transition-colors',
+    'focus:outline-none focus:ring-2 focus:ring-offset-2',
+    'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none'
+  );
+
+  const variantStyles = {
+    primary: cn(
+      'bg-blue-600 text-white hover:bg-blue-700',
+      'focus:ring-blue-500',
+      'dark:bg-blue-500 dark:hover:bg-blue-600'
+    ),
+    secondary: cn(
+      'bg-gray-200 text-gray-900 hover:bg-gray-300',
+      'focus:ring-gray-400',
+      'dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600'
+    ),
+    ghost: cn(
+      'bg-transparent text-gray-700 hover:bg-gray-100',
+      'focus:ring-gray-300',
+      'dark:text-gray-300 dark:hover:bg-gray-800'
+    ),
+  };
+
+  const sizeStyles = {
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-4 py-2 text-base',
+    lg: 'px-6 py-3 text-lg',
+  };
+
+  return (
+    <button
+      className={cn(
+        baseStyles,
+        variantStyles[variant],
+        sizeStyles[size],
+        className
+      )}
+      disabled={disabled || loading}
+      aria-busy={loading}
+      {...props}
+    >
+      {loading && (
+        <svg
+          className="animate-spin h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      )}
+      
+      {!loading && icon && iconPosition === 'left' && (
+        <span className="inline-flex" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      
+      {children}
+      
+      {!loading && icon && iconPosition === 'right' && (
+        <span className="inline-flex" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+    </button>
+  );
+};

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,104 @@
+import type { FC, HTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Título opcional del card
+   */
+  title?: string;
+  
+  /**
+   * Descripción/subtítulo opcional
+   */
+  description?: string;
+  
+  /**
+   * Contenido del card
+   */
+  children: ReactNode;
+  
+  /**
+   * Tamaño del padding interno
+   * @default 'md'
+   */
+  padding?: CardPadding;
+  
+  /**
+   * Si muestra borde o sombra
+   * @default 'shadow'
+   */
+  variant?: 'shadow' | 'border' | 'none';
+}
+
+/**
+ * Componente Card reutilizable para contenedores de contenido
+ * 
+ * @example
+ * ```tsx
+ * <Card title="Compresión" description="Configura la calidad">
+ *   <QualitySlider />
+ * </Card>
+ * 
+ * <Card padding="lg" variant="border">
+ *   <ImagePreview files={files} />
+ * </Card>
+ * ```
+ */
+export const Card: FC<CardProps> = ({
+  title,
+  description,
+  children,
+  padding = 'md',
+  variant = 'shadow',
+  className,
+  ...props
+}) => {
+  const baseStyles = cn(
+    'rounded-lg bg-white dark:bg-gray-800',
+    'transition-colors'
+  );
+
+  const variantStyles = {
+    shadow: 'shadow-md hover:shadow-lg',
+    border: 'border border-gray-200 dark:border-gray-700',
+    none: '',
+  };
+
+  const paddingStyles = {
+    none: '',
+    sm: 'p-3',
+    md: 'p-4',
+    lg: 'p-6',
+  };
+
+  return (
+    <div
+      className={cn(
+        baseStyles,
+        variantStyles[variant],
+        paddingStyles[padding],
+        className
+      )}
+      {...props}
+    >
+      {(title || description) && (
+        <div className="mb-4">
+          {title && (
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {title}
+            </h3>
+          )}
+          {description && (
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {description}
+            </p>
+          )}
+        </div>
+      )}
+      
+      {children}
+    </div>
+  );
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+// Exportar todos los componentes UI desde un solo lugar
+export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from './Button';
+export { Card, type CardProps, type CardPadding } from './Card';
+export { Badge, type BadgeProps, type BadgeVariant, type BadgeSize } from './Badge';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,31 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Combina clases de TailwindCSS evitando conflictos
+ * Usa clsx para condicionales y twMerge para resolver conflictos de Tailwind
+ * 
+ * @example
+ * cn('px-2 py-1', isActive && 'bg-blue-500', 'px-4') // 'py-1 bg-blue-500 px-4'
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+
+/**
+ * Formatea bytes a formato legible (KB, MB, GB)
+ * @param bytes - Número de bytes
+ * @param decimals - Decimales a mostrar (default: 2)
+ * @returns String formateado (ej: "1.5 MB", "234 KB")
+ */
+export function formatBytes(bytes: number, decimals: number = 2): string {
+  if (bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { UIDemo } from '../components/UIDemo';
+---
+
+<Layout 
+	title="UI Components Demo - Pixel Crunch"
+	description="Demostración de componentes UI base"
+>
+	<UIDemo client:load />
+</Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,10 @@
   ],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   }
 }


### PR DESCRIPTION
📋 Resumen
Este PR implementa los componentes UI base necesarios para toda la aplicación: Button, Card y Badge. Todos los componentes son totalmente tipados con TypeScript, responsivos, accesibles y soportan modo oscuro.

✅ Componentes Implementados
🔘 Button (src/components/ui/Button.tsx)
✅ Variantes: primary, secondary, ghost
✅ Tamaños: sm, md, lg
✅ Estados: disabled, loading
✅ Soporte para iconos (izquierda/derecha)
✅ Props completamente tipadas
✅ ARIA labels y accesibilidad
✅ Spinner animado en estado loading
🃏 Card (src/components/ui/Card.tsx)
✅ Props: title, description, children
✅ Variantes: shadow, border, none
✅ Padding configurable: none, sm, md, lg
✅ Soporta cards anidados
✅ Modo oscuro integrado
🏷️ Badge (src/components/ui/Badge.tsx)
✅ Variantes: default, info, success, warning, error
✅ Tamaños: sm, md
✅ Útil para tags de formato (JPG, PNG, WebP)
✅ Colores adaptativos en modo oscuro
🛠️ Utilidades Añadidas
src/lib/utils.ts
✅ Función cn() - Combina clases de Tailwind evitando conflictos (clsx + tailwind-merge)
✅ Función formatBytes() - Formatea bytes a KB/MB/GB
Configuración
✅ Path alias @/* configurado en tsconfig.json
✅ Exportaciones centralizadas en src/components/ui/index.ts
🧪 Testing
✅ Página de demo creada en /demo para verificar todos los componentes
✅ Build de producción pasa sin errores TypeScript
✅ Todos los componentes renderizando correctamente
✅ Responsive verificado (mobile + desktop)
✅ Sin errores en consola
📸 Demo
Puedes ver la demo de los componentes en: http://localhost:4322/demo

🔄 Commits
feat(lib): add utility functions (cn and formatBytes)
feat(ui): add Button component with variants (primary, secondary, ghost)
feat(ui): add Card and Badge components with dark mode support
chore(config): add path alias @/* for imports
feat(ui): add demo page to test components
📚 Documentación
Todos los componentes incluyen:

JSDoc completo con ejemplos de uso
Props tipadas con TypeScript
Interfaces exportadas para reutilización
⚠️ Notas
La página /demo es temporal y puede removerse en futuras PRs
Los componentes están listos para ser usados en Issues https://github.com/JosueMM01/pixel-crunch/issues/4, https://github.com/JosueMM01/pixel-crunch/issues/5, https://github.com/JosueMM01/pixel-crunch/issues/6