### PR TITLE
feat: upload zone (fase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Tu ciclo de trabajo es autónomo, pero debes seguir estos pasos en orden estrict
 
 ### 1. Inicio de Tarea (Gestión de Issues)
 - **Consulta:** Revisa el tablero del proyecto (Project Board) o lista las Issues abiertas.
-- **Selección:** Si no se te asigna una, toma la siguiente Issue en la columna "To Do".
+- **Selección:** Si no se te asigna una, toma la siguiente Issue en la columna "To Do" y muevela a "In progress" para que sepan que estas trabajando en ella.
 - **Lectura:** Lee detenidamente los requisitos de la Issue. Si no son claros, PREGUNTA al usuario antes de escribir código.
 
 ### 2. Configuración de Entorno

--- a/src/components/features/uploader/UploadZone.tsx
+++ b/src/components/features/uploader/UploadZone.tsx
@@ -6,138 +6,138 @@ import { cn, formatBytes } from '@/lib/utils';
 import type { UploadZoneCopy, UploadZoneProps } from '@/types';
 
 const DEFAULT_ACCEPTED_FORMATS = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/svg+xml',
 ];
 
 const DEFAULT_COPY: UploadZoneCopy = {
-  title: 'Sube tus imagenes',
-  description: 'Arrastra archivos aqui o haz clic para seleccionar.',
-  idleLabel: 'Arrastra imagenes aqui o haz clic para seleccionar',
-  draggingLabel: 'Suelta los archivos para cargarlos',
-  processingLabel: 'Procesando archivos...',
-  helperLabel: 'Formatos soportados: JPG, PNG, WebP, GIF',
-  sizeErrorLabel: 'Archivo muy grande. Maximo 10MB.',
-  typeErrorLabel: 'Formato no soportado. Solo JPG, PNG, WebP, GIF.',
+    title: 'Sube tus imagenes',
+    description: 'Arrastra archivos aqui o haz clic para seleccionar.',
+    idleLabel: 'Arrastra imagenes aqui o haz clic para seleccionar',
+    draggingLabel: 'Suelta los archivos para cargarlos',
+    processingLabel: 'Procesando archivos...',
+    helperLabel: 'Formatos soportados: JPG, PNG, WebP, SVG',
+    sizeErrorLabel: 'Archivo muy grande. Maximo 10MB.',
+    typeErrorLabel: 'Formato no soportado. Solo JPG, PNG, WebP, SVG.',
 };
 
 export const UploadZone = ({
-  onFilesSelected,
-  acceptedFormats = DEFAULT_ACCEPTED_FORMATS,
-  maxFileSize = 10 * 1024 * 1024,
-  multiple = true,
-  isProcessing = false,
-  copy,
+    onFilesSelected,
+    acceptedFormats = DEFAULT_ACCEPTED_FORMATS,
+    maxFileSize = 10 * 1024 * 1024,
+    multiple = true,
+    isProcessing = false,
+    copy,
 }: UploadZoneProps) => {
-  const resolvedCopy = useMemo<UploadZoneCopy>(
-    () => ({ ...DEFAULT_COPY, ...copy }),
-    [copy]
-  );
+    const resolvedCopy = useMemo<UploadZoneCopy>(
+        () => ({ ...DEFAULT_COPY, ...copy }),
+        [copy]
+    );
 
-  const accept = useMemo<Record<string, string[]>>(() => {
-    return acceptedFormats.reduce<Record<string, string[]>>((acc, format) => {
-      acc[format] = [];
-      return acc;
-    }, {});
-  }, [acceptedFormats]);
+    const accept = useMemo<Record<string, string[]>>(() => {
+        return acceptedFormats.reduce<Record<string, string[]>>((acc, format) => {
+            acc[format] = [];
+            return acc;
+        }, {});
+    }, [acceptedFormats]);
 
-  const handleDrop = useCallback(
-    (files: File[]) => {
-      if (files.length === 0) return;
-      onFilesSelected?.(files);
-    },
-    [onFilesSelected]
-  );
+    const handleDrop = useCallback(
+        (files: File[]) => {
+            if (files.length === 0) return;
+            onFilesSelected?.(files);
+        },
+        [onFilesSelected]
+    );
 
-  const handleRejected = useCallback(
-    (rejections: FileRejection[]) => {
-      const messages = new Set<string>();
-      rejections.forEach((rejection) => {
-        rejection.errors.forEach((error) => {
-          if (error.code === 'file-too-large') {
-            messages.add(resolvedCopy.sizeErrorLabel);
-            return;
-          }
-          if (error.code === 'file-invalid-type') {
-            messages.add(resolvedCopy.typeErrorLabel);
-            return;
-          }
-          messages.add(error.message);
-        });
-      });
+    const handleRejected = useCallback(
+        (rejections: FileRejection[]) => {
+            const messages = new Set<string>();
+            rejections.forEach((rejection) => {
+                rejection.errors.forEach((error) => {
+                    if (error.code === 'file-too-large') {
+                        messages.add(resolvedCopy.sizeErrorLabel);
+                        return;
+                    }
+                    if (error.code === 'file-invalid-type') {
+                        messages.add(resolvedCopy.typeErrorLabel);
+                        return;
+                    }
+                    messages.add(error.message);
+                });
+            });
 
-      messages.forEach((message) => toast.error(message));
-    },
-    [resolvedCopy]
-  );
+            messages.forEach((message) => toast.error(message));
+        },
+        [resolvedCopy]
+    );
 
-  const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
-    accept,
-    maxSize: maxFileSize,
-    multiple,
-    onDrop: handleDrop,
-    onDropRejected: handleRejected,
-  });
+    const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
+        accept,
+        maxSize: maxFileSize,
+        multiple,
+        onDrop: handleDrop,
+        onDropRejected: handleRejected,
+    });
 
-  const helperText = `${resolvedCopy.helperLabel} • Max ${formatBytes(maxFileSize)}`;
+    const helperText = `${resolvedCopy.helperLabel} • Max ${formatBytes(maxFileSize)}`;
 
-  return (
-    <section className="w-full max-w-5xl mx-auto">
-      <div className="text-center mb-6">
-        <h2 className="text-2xl md:text-3xl font-bold text-monokai-cyan">
-          {resolvedCopy.title}
-        </h2>
-        <p className="mt-2 text-sm md:text-base text-monokai-fg/70">
-          {resolvedCopy.description}
-        </p>
-      </div>
+    return (
+        <section className="w-full max-w-5xl mx-auto">
+            <div className="text-center mb-6">
+                <h2 className="text-2xl md:text-3xl font-bold text-monokai-cyan">
+                    {resolvedCopy.title}
+                </h2>
+                <p className="mt-2 text-sm md:text-base text-monokai-fg/70">
+                    {resolvedCopy.description}
+                </p>
+            </div>
 
-      <div
-        {...getRootProps({
-          className: cn(
-            'group relative rounded-2xl border-2 border-dashed p-6 md:p-10',
-            'transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan',
-            'bg-monokai-bg/60',
-            isDragActive && 'border-monokai-green bg-monokai-green/10',
-            isDragReject && 'border-monokai-pink bg-monokai-pink/10',
-            !isDragActive && !isDragReject && 'border-monokai-purple/40'
-          ),
-        })}
-        aria-busy={isProcessing}
-        aria-live="polite"
-      >
-        <input {...getInputProps()} aria-label="Seleccionar archivos" />
+            <div
+                {...getRootProps({
+                    className: cn(
+                        'group relative rounded-2xl border-2 border-dashed p-6 md:p-10',
+                        'transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan',
+                        'bg-monokai-bg/60',
+                        isDragActive && 'border-monokai-green bg-monokai-green/10',
+                        isDragReject && 'border-monokai-pink bg-monokai-pink/10',
+                        !isDragActive && !isDragReject && 'border-monokai-purple/40'
+                    ),
+                })}
+                aria-busy={isProcessing}
+                aria-live="polite"
+            >
+                <input {...getInputProps()} aria-label="Seleccionar archivos" />
 
-        <div className="flex flex-col items-center gap-4 text-center">
-          <div
-            className={cn(
-              'flex h-14 w-14 items-center justify-center rounded-2xl',
-              'bg-monokai-bg/80 border border-monokai-purple/50',
-              isDragActive && 'border-monokai-green text-monokai-green',
-              isDragReject && 'border-monokai-pink text-monokai-pink'
-            )}
-          >
-            {isDragActive ? (
-              <UploadCloud className="h-6 w-6" aria-hidden="true" />
-            ) : (
-              <ImagePlus className="h-6 w-6" aria-hidden="true" />
-            )}
-          </div>
+                <div className="flex flex-col items-center gap-4 text-center">
+                    <div
+                        className={cn(
+                            'flex h-14 w-14 items-center justify-center rounded-2xl',
+                            'bg-monokai-bg/80 border border-monokai-purple/50',
+                            isDragActive && 'border-monokai-green text-monokai-green',
+                            isDragReject && 'border-monokai-pink text-monokai-pink'
+                        )}
+                    >
+                        {isDragActive ? (
+                            <UploadCloud className="h-6 w-6" aria-hidden="true" />
+                        ) : (
+                            <ImagePlus className="h-6 w-6" aria-hidden="true" />
+                        )}
+                    </div>
 
-          <div className="space-y-2">
-            <p className="text-base md:text-lg font-semibold text-monokai-fg">
-              {isProcessing
-                ? resolvedCopy.processingLabel
-                : isDragActive
-                  ? resolvedCopy.draggingLabel
-                  : resolvedCopy.idleLabel}
-            </p>
-            <p className="text-xs md:text-sm text-monokai-fg/60">{helperText}</p>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+                    <div className="space-y-2">
+                        <p className="text-base md:text-lg font-semibold text-monokai-fg">
+                            {isProcessing
+                                ? resolvedCopy.processingLabel
+                                : isDragActive
+                                    ? resolvedCopy.draggingLabel
+                                    : resolvedCopy.idleLabel}
+                        </p>
+                        <p className="text-xs md:text-sm text-monokai-fg/60">{helperText}</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
 };

--- a/src/components/features/uploader/UploadZone.tsx
+++ b/src/components/features/uploader/UploadZone.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useMemo } from 'react';
+import { useDropzone, type FileRejection } from 'react-dropzone';
+import { ImagePlus, UploadCloud } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn, formatBytes } from '@/lib/utils';
+import type { UploadZoneCopy, UploadZoneProps } from '@/types';
+
+const DEFAULT_ACCEPTED_FORMATS = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+
+const DEFAULT_COPY: UploadZoneCopy = {
+  title: 'Sube tus imagenes',
+  description: 'Arrastra archivos aqui o haz clic para seleccionar.',
+  idleLabel: 'Arrastra imagenes aqui o haz clic para seleccionar',
+  draggingLabel: 'Suelta los archivos para cargarlos',
+  processingLabel: 'Procesando archivos...',
+  helperLabel: 'Formatos soportados: JPG, PNG, WebP, GIF',
+  sizeErrorLabel: 'Archivo muy grande. Maximo 10MB.',
+  typeErrorLabel: 'Formato no soportado. Solo JPG, PNG, WebP, GIF.',
+};
+
+export const UploadZone = ({
+  onFilesSelected,
+  acceptedFormats = DEFAULT_ACCEPTED_FORMATS,
+  maxFileSize = 10 * 1024 * 1024,
+  multiple = true,
+  isProcessing = false,
+  copy,
+}: UploadZoneProps) => {
+  const resolvedCopy = useMemo<UploadZoneCopy>(
+    () => ({ ...DEFAULT_COPY, ...copy }),
+    [copy]
+  );
+
+  const accept = useMemo<Record<string, string[]>>(() => {
+    return acceptedFormats.reduce<Record<string, string[]>>((acc, format) => {
+      acc[format] = [];
+      return acc;
+    }, {});
+  }, [acceptedFormats]);
+
+  const handleDrop = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) return;
+      onFilesSelected?.(files);
+    },
+    [onFilesSelected]
+  );
+
+  const handleRejected = useCallback(
+    (rejections: FileRejection[]) => {
+      const messages = new Set<string>();
+      rejections.forEach((rejection) => {
+        rejection.errors.forEach((error) => {
+          if (error.code === 'file-too-large') {
+            messages.add(resolvedCopy.sizeErrorLabel);
+            return;
+          }
+          if (error.code === 'file-invalid-type') {
+            messages.add(resolvedCopy.typeErrorLabel);
+            return;
+          }
+          messages.add(error.message);
+        });
+      });
+
+      messages.forEach((message) => toast.error(message));
+    },
+    [resolvedCopy]
+  );
+
+  const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
+    accept,
+    maxSize: maxFileSize,
+    multiple,
+    onDrop: handleDrop,
+    onDropRejected: handleRejected,
+  });
+
+  const helperText = `${resolvedCopy.helperLabel} • Max ${formatBytes(maxFileSize)}`;
+
+  return (
+    <section className="w-full max-w-5xl mx-auto">
+      <div className="text-center mb-6">
+        <h2 className="text-2xl md:text-3xl font-bold text-monokai-cyan">
+          {resolvedCopy.title}
+        </h2>
+        <p className="mt-2 text-sm md:text-base text-monokai-fg/70">
+          {resolvedCopy.description}
+        </p>
+      </div>
+
+      <div
+        {...getRootProps({
+          className: cn(
+            'group relative rounded-2xl border-2 border-dashed p-6 md:p-10',
+            'transition-colors outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan',
+            'bg-monokai-bg/60',
+            isDragActive && 'border-monokai-green bg-monokai-green/10',
+            isDragReject && 'border-monokai-pink bg-monokai-pink/10',
+            !isDragActive && !isDragReject && 'border-monokai-purple/40'
+          ),
+        })}
+        aria-busy={isProcessing}
+        aria-live="polite"
+      >
+        <input {...getInputProps()} aria-label="Seleccionar archivos" />
+
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div
+            className={cn(
+              'flex h-14 w-14 items-center justify-center rounded-2xl',
+              'bg-monokai-bg/80 border border-monokai-purple/50',
+              isDragActive && 'border-monokai-green text-monokai-green',
+              isDragReject && 'border-monokai-pink text-monokai-pink'
+            )}
+          >
+            {isDragActive ? (
+              <UploadCloud className="h-6 w-6" aria-hidden="true" />
+            ) : (
+              <ImagePlus className="h-6 w-6" aria-hidden="true" />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-base md:text-lg font-semibold text-monokai-fg">
+              {isProcessing
+                ? resolvedCopy.processingLabel
+                : isDragActive
+                  ? resolvedCopy.draggingLabel
+                  : resolvedCopy.idleLabel}
+            </p>
+            <p className="text-xs md:text-sm text-monokai-fg/60">{helperText}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/features/uploader/index.ts
+++ b/src/components/features/uploader/index.ts
@@ -1,0 +1,1 @@
+export { UploadZone } from './UploadZone';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -39,8 +39,8 @@
     "idleLabel": "Drag images here or click to select",
     "draggingLabel": "Drop files to upload",
     "processingLabel": "Processing files...",
-    "helperLabel": "Supported formats: JPG, PNG, WebP, GIF",
+    "helperLabel": "Supported formats: JPG, PNG, WebP, SVG",
     "sizeErrorLabel": "File too large. Max 10MB.",
-    "typeErrorLabel": "Unsupported format. Only JPG, PNG, WebP, GIF."
+    "typeErrorLabel": "Unsupported format. Only JPG, PNG, WebP, SVG."
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -32,5 +32,15 @@
   "formats": {
     "title": "Supported Formats",
     "description": "JPG, PNG, WebP and more"
+  },
+  "upload": {
+    "title": "Upload your images",
+    "description": "Drag images here or click to select.",
+    "idleLabel": "Drag images here or click to select",
+    "draggingLabel": "Drop files to upload",
+    "processingLabel": "Processing files...",
+    "helperLabel": "Supported formats: JPG, PNG, WebP, GIF",
+    "sizeErrorLabel": "File too large. Max 10MB.",
+    "typeErrorLabel": "Unsupported format. Only JPG, PNG, WebP, GIF."
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -32,5 +32,15 @@
   "formats": {
     "title": "Formatos Soportados",
     "description": "JPG, PNG, WebP y más"
+  },
+  "upload": {
+    "title": "Sube tus imagenes",
+    "description": "Arrastra imagenes aqui o haz clic para seleccionar.",
+    "idleLabel": "Arrastra imagenes aqui o haz clic para seleccionar",
+    "draggingLabel": "Suelta los archivos para cargarlos",
+    "processingLabel": "Procesando archivos...",
+    "helperLabel": "Formatos soportados: JPG, PNG, WebP, GIF",
+    "sizeErrorLabel": "Archivo muy grande. Maximo 10MB.",
+    "typeErrorLabel": "Formato no soportado. Solo JPG, PNG, WebP, GIF."
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -39,8 +39,8 @@
     "idleLabel": "Arrastra imagenes aqui o haz clic para seleccionar",
     "draggingLabel": "Suelta los archivos para cargarlos",
     "processingLabel": "Procesando archivos...",
-    "helperLabel": "Formatos soportados: JPG, PNG, WebP, GIF",
+    "helperLabel": "Formatos soportados: JPG, PNG, WebP, SVG",
     "sizeErrorLabel": "Archivo muy grande. Maximo 10MB.",
-    "typeErrorLabel": "Formato no soportado. Solo JPG, PNG, WebP, GIF."
+    "typeErrorLabel": "Formato no soportado. Solo JPG, PNG, WebP, SVG."
   }
 }

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import { UploadZone } from '../../components/features/uploader';
 import translations from '../../i18n/en.json';
 
 const t = translations;
@@ -80,6 +81,13 @@ const t = translations;
 					</div>
 				</div>
 			</div>
+		</section>
+
+		<section class="px-4 pb-16 md:pb-24">
+			<UploadZone
+				client:load
+				copy={t.upload}
+			/>
 		</section>
 
 		<!-- Benefits Section -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { UploadZone } from '../components/features/uploader';
 import translations from '../i18n/es.json';
 
 const t = translations;
@@ -80,6 +81,13 @@ const t = translations;
 					</div>
 				</div>
 			</div>
+		</section>
+
+		<section class="px-4 pb-16 md:pb-24">
+			<UploadZone
+				client:load
+				copy={t.upload}
+			/>
 		</section>
 
 		<!-- Benefits Section -->

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { UploadZoneCopy, UploadZoneProps } from './upload';

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -1,0 +1,19 @@
+export interface UploadZoneCopy {
+  title: string;
+  description: string;
+  idleLabel: string;
+  draggingLabel: string;
+  processingLabel: string;
+  helperLabel: string;
+  sizeErrorLabel: string;
+  typeErrorLabel: string;
+}
+
+export interface UploadZoneProps {
+  onFilesSelected?: (files: File[]) => void;
+  acceptedFormats?: string[];
+  maxFileSize?: number;
+  multiple?: boolean;
+  isProcessing?: boolean;
+  copy?: Partial<UploadZoneCopy>;
+}


### PR DESCRIPTION
## Resumen
- Componente UploadZone con drag & drop usando react-dropzone.
- Validaciones de formato y tamaño con toasts (sonner).
- Textos bilingues y seccion integrada en ES/EN.

## Cambios
- `src/components/features/uploader/UploadZone.tsx`
- `src/types/*`
- `src/i18n/*`
- `src/pages/index.astro`
- `src/pages/en/index.astro`

## Verificacion
- DevTools sin errores en consola.

Closes #5