### PR TITLE
feat: theme system with useTheme hook (phase 1)

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,5 +1,6 @@
 ---
 import LanguageSwitcher from '../LanguageSwitcher';
+import ThemeToggle from '../ui/ThemeToggle';
 ---
 
 <header class="sticky top-0 z-40 w-full border-b border-gray-200 dark:border-white/10 bg-white/80 dark:bg-monokai-bg/80 backdrop-blur-sm">
@@ -32,8 +33,9 @@ import LanguageSwitcher from '../LanguageSwitcher';
         </a>
       </div>
 
-      <!-- Language Switcher -->
-      <div class="flex items-center">
+      <!-- Theme + Language Switcher -->
+      <div class="flex items-center gap-2">
+        <ThemeToggle client:load />
         <LanguageSwitcher client:load />
       </div>
     </nav>

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/hooks/useTheme';
+
+export default function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const isDark = resolvedTheme === 'dark';
+  const nextTheme = isDark ? 'light' : 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(nextTheme)}
+      className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-brand-cyan/30 bg-white/70 dark:bg-monokai-bg/80 p-2.5 text-gray-700 dark:text-brand-cyan-light hover:border-brand-blue dark:hover:border-brand-cyan-light transition-colors backdrop-blur-sm"
+      aria-label={isDark ? 'Activar modo claro' : 'Activar modo oscuro'}
+      title={theme === 'system' ? `Tema del sistema (${resolvedTheme})` : `Tema: ${theme}`}
+    >
+      {isDark ? <Sun className="h-4 w-4" aria-hidden="true" /> : <Moon className="h-4 w-4" aria-hidden="true" />}
+    </button>
+  );
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+interface UseThemeReturn {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: ResolvedTheme;
+}
+
+const STORAGE_KEY = 'theme';
+const MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  return window.matchMedia(MEDIA_QUERY).matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+
+  const value = localStorage.getItem(STORAGE_KEY);
+  if (value === 'light' || value === 'dark' || value === 'system') {
+    return value;
+  }
+
+  return 'system';
+}
+
+function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme === 'system') {
+    return getSystemTheme();
+  }
+
+  return theme;
+}
+
+function applyThemeClass(theme: Theme): ResolvedTheme {
+  const nextResolvedTheme = resolveTheme(theme);
+
+  if (typeof document !== 'undefined') {
+    document.documentElement.classList.toggle('dark', nextResolvedTheme === 'dark');
+  }
+
+  return nextResolvedTheme;
+}
+
+export function useTheme(): UseThemeReturn {
+  const [theme, setThemeState] = useState<Theme>('system');
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('dark');
+
+  useEffect(() => {
+    const initialTheme = getStoredTheme();
+    setThemeState(initialTheme);
+    setResolvedTheme(applyThemeClass(initialTheme));
+
+    const mediaQuery = window.matchMedia(MEDIA_QUERY);
+
+    const onSystemThemeChange = () => {
+      const currentTheme = getStoredTheme();
+      if (currentTheme !== 'system') {
+        return;
+      }
+
+      setResolvedTheme(applyThemeClass('system'));
+    };
+
+    mediaQuery.addEventListener('change', onSystemThemeChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', onSystemThemeChange);
+    };
+  }, []);
+
+  const setTheme = useCallback((nextTheme: Theme) => {
+    setThemeState(nextTheme);
+    localStorage.setItem(STORAGE_KEY, nextTheme);
+    setResolvedTheme(applyThemeClass(nextTheme));
+  }, []);
+
+  return {
+    theme,
+    setTheme,
+    resolvedTheme,
+  };
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="es" class="dark">
+<html lang="es">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -55,13 +55,18 @@ const {
 		<title>{title}</title>
 		
 		<script is:inline>
-			// Sistema de tema oscuro
-			const theme = localStorage.getItem('theme') || 'dark';
-			if (theme === 'dark') {
-				document.documentElement.classList.add('dark');
-			} else {
-				document.documentElement.classList.remove('dark');
-			}
+			(() => {
+				const storageKey = 'theme';
+				const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+				const savedTheme = localStorage.getItem(storageKey);
+				const theme =
+					savedTheme === 'light' || savedTheme === 'dark' || savedTheme === 'system'
+						? savedTheme
+						: 'system';
+
+				const shouldUseDark = theme === 'dark' || (theme === 'system' && mediaQuery.matches);
+				document.documentElement.classList.toggle('dark', shouldUseDark);
+			})();
 		</script>
 	</head>
 	<body class="antialiased font-sans flex flex-col min-h-screen bg-white dark:bg-monokai-bg text-gray-900 dark:text-monokai-fg transition-colors duration-300">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
 	--font-sans: "Fira Code", ui-sans-serif, system-ui, sans-serif;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,6 +25,28 @@
 	--color-brand-yellow: #E6DB74;
 }
 
+:root {
+	--color-monokai-bg: #f8fafc;
+	--color-monokai-fg: #0f172a;
+	--color-monokai-pink: #be185d;
+	--color-monokai-green: #15803d;
+	--color-monokai-yellow: #a16207;
+	--color-monokai-purple: #7c3aed;
+	--color-monokai-cyan: #0e7490;
+	--color-monokai-orange: #c2410c;
+}
+
+html.dark {
+	--color-monokai-bg: #272822;
+	--color-monokai-fg: #F8F8F2;
+	--color-monokai-pink: #F92672;
+	--color-monokai-green: #A6E22E;
+	--color-monokai-yellow: #E6DB74;
+	--color-monokai-purple: #AE81FF;
+	--color-monokai-cyan: #66D9EF;
+	--color-monokai-orange: #FD971F;
+}
+
 * {
 	box-sizing: border-box;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,16 +34,7 @@ scroll-behavior: smooth;
 }
 
 body {
-	/* margin: 0; */
-	background-color: #272822;
-	color: #F8F8F2;
 	transition: background-color 0.3s ease;
-}
-
-body.dark,
-html.dark body {
-background-color: #272822;
-color: #F8F8F2;
 }
 
 /* Animaciones suaves */


### PR DESCRIPTION
## 📋 Summary
Implementa la Issue #7 agregando un sistema de tema oscuro/claro persistente con detección de preferencia del sistema.

## ✅ Cambios principales
- Se crea `useTheme` en `src/hooks/useTheme.ts` con:
  - `theme`: `light | dark | system`
  - `resolvedTheme`: `light | dark`
  - `setTheme(theme)`
  - Persistencia en `localStorage` (`theme`)
  - Detección de sistema con `window.matchMedia`
  - Listener con cleanup al desmontar
- Se crea `ThemeToggle` en `src/components/ui/ThemeToggle.tsx`
  - Toggle inmediato dark/light con iconos `Sun`/`Moon`
  - Estados accesibles con `aria-label`
- Se integra `ThemeToggle` en header
- Se actualiza `Layout.astro` con script inline anti-FOUC
  - Resuelve tema antes del render según `localStorage` y sistema
- Se ajusta `global.css` para no forzar modo oscuro por defecto

## 🧪 Verificación
- `npm run build` ✅
- Chrome DevTools MCP:
  - Sin `error/warn` en consola en `/` y `/en` ✅
  - Toggle de tema cambia visualmente sin delay ✅

## 📁 Archivos
- `src/hooks/useTheme.ts`
- `src/components/ui/ThemeToggle.tsx`
- `src/components/layout/Header.astro`
- `src/layouts/Layout.astro`
- `src/styles/global.css`

Closes #7