### PR TITLE
feat: integrate Sonner notifications system (phase 1)

### DIFF
--- a/src/components/features/uploader/UploadZone.tsx
+++ b/src/components/features/uploader/UploadZone.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { useDropzone, type FileRejection } from 'react-dropzone';
 import { ImagePlus, UploadCloud } from 'lucide-react';
-import { toast } from 'sonner';
 import { cn, formatBytes } from '@/lib/utils';
+import { showError, showSuccess } from '@/lib/toast';
 import type { UploadZoneCopy, UploadZoneProps } from '@/types';
 
 const DEFAULT_ACCEPTED_FORMATS = [
@@ -19,6 +19,7 @@ const DEFAULT_COPY: UploadZoneCopy = {
     draggingLabel: 'Suelta los archivos para cargarlos',
     processingLabel: 'Procesando archivos...',
     helperLabel: 'Formatos soportados: JPG, PNG, WebP, SVG',
+    successLabel: '{count} imagen(es) cargada(s) correctamente.',
     sizeErrorLabel: 'Archivo muy grande. Maximo 10MB.',
     typeErrorLabel: 'Formato no soportado. Solo JPG, PNG, WebP, SVG.',
 };
@@ -47,8 +48,14 @@ export const UploadZone = ({
         (files: File[]) => {
             if (files.length === 0) return;
             onFilesSelected?.(files);
+
+            const successMessage = resolvedCopy.successLabel.replace(
+                '{count}',
+                String(files.length)
+            );
+            showSuccess(successMessage);
         },
-        [onFilesSelected]
+        [onFilesSelected, resolvedCopy.successLabel]
     );
 
     const handleRejected = useCallback(
@@ -68,7 +75,7 @@ export const UploadZone = ({
                 });
             });
 
-            messages.forEach((message) => toast.error(message));
+            messages.forEach((message) => showError(message));
         },
         [resolvedCopy]
     );

--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -1,0 +1,16 @@
+import { Toaster as SonnerToaster } from 'sonner';
+import { useTheme } from '@/hooks/useTheme';
+
+export function Toaster() {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <SonnerToaster
+      position="bottom-right"
+      richColors
+      closeButton
+      duration={3200}
+      theme={resolvedTheme}
+    />
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,6 +40,7 @@
     "draggingLabel": "Drop files to upload",
     "processingLabel": "Processing files...",
     "helperLabel": "Supported formats: JPG, PNG, WebP, SVG",
+    "successLabel": "{count} image(s) uploaded successfully.",
     "sizeErrorLabel": "File too large. Max 10MB.",
     "typeErrorLabel": "Unsupported format. Only JPG, PNG, WebP, SVG."
   },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -40,6 +40,7 @@
     "draggingLabel": "Suelta los archivos para cargarlos",
     "processingLabel": "Procesando archivos...",
     "helperLabel": "Formatos soportados: JPG, PNG, WebP, SVG",
+    "successLabel": "{count} imagen(es) cargada(s) correctamente.",
     "sizeErrorLabel": "Archivo muy grande. Maximo 10MB.",
     "typeErrorLabel": "Formato no soportado. Solo JPG, PNG, WebP, SVG."
   },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import Header from '../components/layout/Header.astro';
 import Footer from '../components/layout/Footer.astro';
+import { Toaster } from '../components/ui/Toaster';
 
 interface Props {
 	title?: string;
@@ -74,6 +75,7 @@ const {
 		<main class="flex-1 pb-8">
 			<slot />
 		</main>
+		<Toaster client:load />
 		<Footer />
 	</body>
 </html>

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,17 @@
+import { toast } from 'sonner';
+
+export function showSuccess(message: string): void {
+  toast.success(message);
+}
+
+export function showError(message: string): void {
+  toast.error(message);
+}
+
+export function showWarning(message: string): void {
+  toast.warning(message);
+}
+
+export function showInfo(message: string): void {
+  toast.info(message);
+}

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -5,6 +5,7 @@ export interface UploadZoneCopy {
   draggingLabel: string;
   processingLabel: string;
   helperLabel: string;
+  successLabel: string;
   sizeErrorLabel: string;
   typeErrorLabel: string;
 }


### PR DESCRIPTION
## 📋 Summary
Implementa la Issue #8 integrando Sonner para notificaciones globales y conectándolo al flujo de carga de imágenes.

## ✅ Cambios principales
- Se crea wrapper `Toaster` en `src/components/ui/Toaster.tsx`
  - Posición `bottom-right`
  - `richColors` y `closeButton`
  - Tema sincronizado con `useTheme` (`resolvedTheme`)
- Se integra `Toaster` global en `src/layouts/Layout.astro` antes del cierre de `body`
- Se crean helpers en `src/lib/toast.ts`
  - `showSuccess`, `showError`, `showWarning`, `showInfo`
- Se actualiza `UploadZone` para usar helpers de toast
  - Error por tipo/tamaño inválido
  - Éxito al cargar archivos con mensaje localizado
- Se extiende i18n de upload con `successLabel` en español e inglés

## 🧪 Verificación
- `npm run build` ✅
- DevTools MCP:
  - `Toaster` renderizado en layout (`region Notifications`) ✅
  - Toast de error mostrado para archivo inválido ✅
  - Toast de éxito mostrado para archivo válido ✅
  - Sin `error/warn` en consola ✅

## 📁 Archivos
- `src/components/ui/Toaster.tsx`
- `src/lib/toast.ts`
- `src/layouts/Layout.astro`
- `src/components/features/uploader/UploadZone.tsx`
- `src/types/upload.ts`
- `src/i18n/es.json`
- `src/i18n/en.json`

Closes #8