### PR TITLE
docs: mark Phase 1 completed and prepare Phase 2

### DIFF
--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -12,7 +12,7 @@
 
 ---
 
-## 🔄 Fase 1: UI Base (SIGUIENTE)
+## ✅ Fase 1: UI Base (COMPLETADA)
 **Branch:** `feat/ui-base`  
 **Objetivo:** Interfaz funcional sin lógica de compresión.
 
@@ -25,15 +25,15 @@
 6. Solicitar revisión
 
 ### Tareas:
-- [ ] Crear componentes base en `src/components/ui/`
-  - [ ] Button.tsx
-  - [ ] Card.tsx
-  - [ ] Badge.tsx
-- [ ] Layout principal con Header/Footer
-- [ ] Componente `UploadZone.tsx` (react-dropzone)
-- [ ] Componente `ImagePreview.tsx` (mostrar miniaturas)
-- [ ] Sistema de tema oscuro con hook `useTheme.ts`
-- [ ] Sistema de notificaciones con Sonner
+- [x] Crear componentes base en `src/components/ui/`
+  - [x] Button.tsx
+  - [x] Card.tsx
+  - [x] Badge.tsx
+- [x] Layout principal con Header/Footer
+- [x] Componente `UploadZone.tsx` (react-dropzone)
+- [x] Componente `ImagePreview.tsx` (mostrar miniaturas)
+- [x] Sistema de tema oscuro con hook `useTheme.ts`
+- [x] Sistema de notificaciones con Sonner
 
 ### Entregables:
 - Usuario puede arrastrar archivos

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,7 +12,7 @@
   },
   "status": {
     "inDevelopment": "In Development",
-    "phase": "Phase 0 completed. Coming soon: Upload and compression UI."
+    "phase": "Phase 1 completed. Coming soon: Compression engine (Phase 2)."
   },
   "benefits": {
     "title": "Why Pixel Crunch?",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -12,7 +12,7 @@
   },
   "status": {
     "inDevelopment": "En desarrollo",
-    "phase": "Fase 0 completada. Próximamente: UI de upload y compresión."
+    "phase": "Fase 1 completada. Próximamente: motor de compresión (Fase 2)."
   },
   "benefits": {
     "title": "¿Por qué Pixel Crunch?",


### PR DESCRIPTION
## 📋 Summary
Actualiza estado del proyecto tras completar Fase 1.

## ✅ Cambios
- Actualiza `status.phase` en i18n ES/EN para indicar que Fase 1 está completada
- Marca Fase 1 como `COMPLETADA` en `docs/PHASES.md`
- Marca todas las tareas de Fase 1 con `[x]`

## 🎯 Objetivo
Dejar `development` listo para merge a `main` como cierre de Fase 1 y arranque de Fase 2.

## 📁 Archivos
- `src/i18n/es.json`
- `src/i18n/en.json`
- `docs/PHASES.md`