### PR TITLE
feat(compression): add CompressionStats component (issue #17)

### DIFF
--- a/src/components/features/compressor/CompressionStats.tsx
+++ b/src/components/features/compressor/CompressionStats.tsx
@@ -9,14 +9,14 @@ import type {
 } from '@/types';
 
 const DEFAULT_COPY: CompressionStatsCopy = {
-  title: 'Estadisticas de compresion',
-  description: 'Compara el tamano original frente al comprimido.',
-  emptyStateLabel: 'Aun no hay datos de compresion para mostrar.',
+  title: 'Compression stats',
+  description: 'Compare original size against compressed size.',
+  emptyStateLabel: 'No compression data to show yet.',
   originalLabel: 'Original',
-  compressedLabel: 'Comprimido',
-  savingsLabel: 'Ahorro',
-  percentageLabel: 'Reduccion',
-  estimatedLabel: 'Estimado',
+  compressedLabel: 'Compressed',
+  savingsLabel: 'Savings',
+  percentageLabel: 'Reduction',
+  estimatedLabel: 'Estimated',
   errorLabel: 'Error',
 };
 
@@ -25,10 +25,23 @@ interface NormalizedStatsItem extends CompressionStatsItem {
   safeCompressed: number;
   savingsBytes: number;
   savingsPercent: number;
+  isComparable: boolean;
 }
 
 function toNormalizedItem(item: CompressionStatsItem): NormalizedStatsItem {
   const safeOriginal = Math.max(0, item.originalBytes);
+
+  if (item.hasError) {
+    return {
+      ...item,
+      safeOriginal,
+      safeCompressed: 0,
+      savingsBytes: 0,
+      savingsPercent: 0,
+      isComparable: false,
+    };
+  }
+
   const safeCompressed = Math.max(0, item.compressedBytes);
   const savingsBytes = safeOriginal - safeCompressed;
   const savingsPercent = safeOriginal === 0
@@ -41,6 +54,7 @@ function toNormalizedItem(item: CompressionStatsItem): NormalizedStatsItem {
     safeCompressed,
     savingsBytes,
     savingsPercent,
+    isComparable: true,
   };
 }
 
@@ -52,15 +66,15 @@ function getSavingsBadgeVariant(savingsBytes: number): 'success' | 'warning' | '
 
 function formatSignedBytes(value: number): string {
   const absValue = Math.abs(value);
-  if (value > 0) return `-${formatBytes(absValue)}`;
-  if (value < 0) return `+${formatBytes(absValue)}`;
+  if (value > 0) return formatBytes(absValue);
+  if (value < 0) return `-${formatBytes(absValue)}`;
   return formatBytes(0);
 }
 
 function formatSignedPercent(value: number): string {
   const absValue = Math.abs(value).toFixed(1);
-  if (value > 0) return `-${absValue}%`;
-  if (value < 0) return `+${absValue}%`;
+  if (value > 0) return `${absValue}%`;
+  if (value < 0) return `-${absValue}%`;
   return '0.0%';
 }
 
@@ -76,8 +90,9 @@ export function CompressionStats({ items, copy }: CompressionStatsProps) {
   );
 
   const totals = useMemo(() => {
-    const original = normalizedItems.reduce((sum, item) => sum + item.safeOriginal, 0);
-    const compressed = normalizedItems.reduce((sum, item) => sum + item.safeCompressed, 0);
+    const comparableItems = normalizedItems.filter((item) => item.isComparable);
+    const original = comparableItems.reduce((sum, item) => sum + item.safeOriginal, 0);
+    const compressed = comparableItems.reduce((sum, item) => sum + item.safeCompressed, 0);
     const savingsBytes = original - compressed;
     const savingsPercent = original === 0 ? 0 : (savingsBytes / original) * 100;
 
@@ -172,13 +187,13 @@ export function CompressionStats({ items, copy }: CompressionStatsProps) {
                         {resolvedCopy.originalLabel}: {formatBytes(item.safeOriginal)}
                       </span>
                       <span>
-                        {resolvedCopy.compressedLabel}: {formatBytes(item.safeCompressed)}
+                        {resolvedCopy.compressedLabel}: {item.isComparable ? formatBytes(item.safeCompressed) : '--'}
                       </span>
                       <span>
-                        {resolvedCopy.savingsLabel}: {formatSignedBytes(item.savingsBytes)}
+                        {resolvedCopy.savingsLabel}: {item.isComparable ? formatSignedBytes(item.savingsBytes) : '--'}
                       </span>
                       <span>
-                        {resolvedCopy.percentageLabel}: {formatSignedPercent(item.savingsPercent)}
+                        {resolvedCopy.percentageLabel}: {item.isComparable ? formatSignedPercent(item.savingsPercent) : '--'}
                       </span>
                     </div>
                   </div>

--- a/src/components/features/compressor/CompressionStats.tsx
+++ b/src/components/features/compressor/CompressionStats.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { formatBytes } from '@/lib/utils';
+import type {
+  CompressionStatsCopy,
+  CompressionStatsItem,
+  CompressionStatsProps,
+} from '@/types';
+
+const DEFAULT_COPY: CompressionStatsCopy = {
+  title: 'Estadisticas de compresion',
+  description: 'Compara el tamano original frente al comprimido.',
+  emptyStateLabel: 'Aun no hay datos de compresion para mostrar.',
+  originalLabel: 'Original',
+  compressedLabel: 'Comprimido',
+  savingsLabel: 'Ahorro',
+  percentageLabel: 'Reduccion',
+  estimatedLabel: 'Estimado',
+  errorLabel: 'Error',
+};
+
+interface NormalizedStatsItem extends CompressionStatsItem {
+  safeOriginal: number;
+  safeCompressed: number;
+  savingsBytes: number;
+  savingsPercent: number;
+}
+
+function toNormalizedItem(item: CompressionStatsItem): NormalizedStatsItem {
+  const safeOriginal = Math.max(0, item.originalBytes);
+  const safeCompressed = Math.max(0, item.compressedBytes);
+  const savingsBytes = safeOriginal - safeCompressed;
+  const savingsPercent = safeOriginal === 0
+    ? 0
+    : (savingsBytes / safeOriginal) * 100;
+
+  return {
+    ...item,
+    safeOriginal,
+    safeCompressed,
+    savingsBytes,
+    savingsPercent,
+  };
+}
+
+function getSavingsBadgeVariant(savingsBytes: number): 'success' | 'warning' | 'error' {
+  if (savingsBytes > 0) return 'success';
+  if (savingsBytes === 0) return 'warning';
+  return 'error';
+}
+
+function formatSignedBytes(value: number): string {
+  const absValue = Math.abs(value);
+  if (value > 0) return `-${formatBytes(absValue)}`;
+  if (value < 0) return `+${formatBytes(absValue)}`;
+  return formatBytes(0);
+}
+
+function formatSignedPercent(value: number): string {
+  const absValue = Math.abs(value).toFixed(1);
+  if (value > 0) return `-${absValue}%`;
+  if (value < 0) return `+${absValue}%`;
+  return '0.0%';
+}
+
+export function CompressionStats({ items, copy }: CompressionStatsProps) {
+  const resolvedCopy = useMemo<CompressionStatsCopy>(
+    () => ({ ...DEFAULT_COPY, ...copy }),
+    [copy]
+  );
+
+  const normalizedItems = useMemo(
+    () => items.map(toNormalizedItem),
+    [items]
+  );
+
+  const totals = useMemo(() => {
+    const original = normalizedItems.reduce((sum, item) => sum + item.safeOriginal, 0);
+    const compressed = normalizedItems.reduce((sum, item) => sum + item.safeCompressed, 0);
+    const savingsBytes = original - compressed;
+    const savingsPercent = original === 0 ? 0 : (savingsBytes / original) * 100;
+
+    return {
+      original,
+      compressed,
+      savingsBytes,
+      savingsPercent,
+    };
+  }, [normalizedItems]);
+
+  return (
+    <section className="w-full max-w-5xl mx-auto space-y-4">
+      <Card variant="border" className="border-monokai-green/40 bg-monokai-bg/50">
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xl md:text-2xl font-semibold text-monokai-green">
+              {resolvedCopy.title}
+            </h3>
+            <p className="mt-1 text-sm md:text-base text-monokai-fg/70">
+              {resolvedCopy.description}
+            </p>
+          </div>
+
+          {normalizedItems.length === 0 ? (
+            <p className="text-sm md:text-base text-monokai-fg/70">
+              {resolvedCopy.emptyStateLabel}
+            </p>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <Card variant="border" padding="sm" className="border-monokai-cyan/30 bg-monokai-bg/60">
+                  <p className="text-xs text-monokai-fg/70">{resolvedCopy.originalLabel}</p>
+                  <p className="text-sm md:text-base font-semibold text-monokai-cyan">
+                    {formatBytes(totals.original)}
+                  </p>
+                </Card>
+
+                <Card variant="border" padding="sm" className="border-monokai-purple/30 bg-monokai-bg/60">
+                  <p className="text-xs text-monokai-fg/70">{resolvedCopy.compressedLabel}</p>
+                  <p className="text-sm md:text-base font-semibold text-monokai-purple">
+                    {formatBytes(totals.compressed)}
+                  </p>
+                </Card>
+
+                <Card variant="border" padding="sm" className="border-monokai-green/30 bg-monokai-bg/60">
+                  <p className="text-xs text-monokai-fg/70">{resolvedCopy.savingsLabel}</p>
+                  <p className="text-sm md:text-base font-semibold text-monokai-green">
+                    {formatSignedBytes(totals.savingsBytes)}
+                  </p>
+                </Card>
+
+                <Card variant="border" padding="sm" className="border-monokai-yellow/30 bg-monokai-bg/60">
+                  <p className="text-xs text-monokai-fg/70">{resolvedCopy.percentageLabel}</p>
+                  <p className="text-sm md:text-base font-semibold text-monokai-yellow">
+                    {formatSignedPercent(totals.savingsPercent)}
+                  </p>
+                </Card>
+              </div>
+
+              <div className="space-y-2" aria-label={resolvedCopy.title}>
+                {normalizedItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-md border border-monokai-fg/20 bg-monokai-bg/60 p-3"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p
+                        className="text-sm font-medium text-monokai-fg truncate"
+                        title={item.filename}
+                      >
+                        {item.filename}
+                      </p>
+
+                      <div className="flex items-center gap-2">
+                        <Badge size="sm" className="bg-monokai-fg/10 text-monokai-fg">
+                          {resolvedCopy.estimatedLabel}
+                        </Badge>
+                        {item.hasError && (
+                          <Badge variant="error" size="sm">
+                            {resolvedCopy.errorLabel}
+                          </Badge>
+                        )}
+                        <Badge variant={getSavingsBadgeVariant(item.savingsBytes)} size="sm">
+                          {formatSignedPercent(item.savingsPercent)}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2 text-xs text-monokai-fg/80">
+                      <span>
+                        {resolvedCopy.originalLabel}: {formatBytes(item.safeOriginal)}
+                      </span>
+                      <span>
+                        {resolvedCopy.compressedLabel}: {formatBytes(item.safeCompressed)}
+                      </span>
+                      <span>
+                        {resolvedCopy.savingsLabel}: {formatSignedBytes(item.savingsBytes)}
+                      </span>
+                      <span>
+                        {resolvedCopy.percentageLabel}: {formatSignedPercent(item.savingsPercent)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/features/compressor/CompressionStats.tsx
+++ b/src/components/features/compressor/CompressionStats.tsx
@@ -176,9 +176,11 @@ export function CompressionStats({ items, copy }: CompressionStatsProps) {
                             {resolvedCopy.errorLabel}
                           </Badge>
                         )}
-                        <Badge variant={getSavingsBadgeVariant(item.savingsBytes)} size="sm">
-                          {formatSignedPercent(item.savingsPercent)}
-                        </Badge>
+                        {item.isComparable && (
+                          <Badge variant={getSavingsBadgeVariant(item.savingsBytes)} size="sm">
+                            {formatSignedPercent(item.savingsPercent)}
+                          </Badge>
+                        )}
                       </div>
                     </div>
 

--- a/src/components/features/compressor/index.ts
+++ b/src/components/features/compressor/index.ts
@@ -1,1 +1,2 @@
 export { QualitySlider } from './QualitySlider';
+export { CompressionStats } from './CompressionStats';

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -1,12 +1,33 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ImagePreview } from './ImagePreview';
 import { UploadZone } from './UploadZone';
-import { QualitySlider } from '../compressor';
+import { CompressionStats, QualitySlider } from '../compressor';
+import type { CompressionStatsItem } from '@/types';
 import type { UploaderPanelProps } from '@/types';
 
-export function UploaderPanel({ uploadCopy, previewCopy, qualityCopy }: UploaderPanelProps) {
+function estimateCompressedSize(bytes: number, quality: number): number {
+  const safeBytes = Math.max(0, bytes);
+  const ratio = 0.35 + (quality * 0.65);
+  return Math.round(safeBytes * ratio);
+}
+
+export function UploaderPanel({
+  uploadCopy,
+  previewCopy,
+  qualityCopy,
+  compressionStatsCopy,
+}: UploaderPanelProps) {
   const [files, setFiles] = useState<File[]>([]);
   const [quality, setQuality] = useState<number>(0.8);
+
+  const statsItems = useMemo<CompressionStatsItem[]>(() => {
+    return files.map((file, index) => ({
+      id: `${file.name}-${file.lastModified}-${index}`,
+      filename: file.name,
+      originalBytes: file.size,
+      compressedBytes: estimateCompressedSize(file.size, quality),
+    }));
+  }, [files, quality]);
 
   const handleFilesSelected = useCallback((incomingFiles: File[]) => {
     setFiles((previousFiles) => [...previousFiles, ...incomingFiles]);
@@ -22,6 +43,7 @@ export function UploaderPanel({ uploadCopy, previewCopy, qualityCopy }: Uploader
     <div className="space-y-8">
       <UploadZone onFilesSelected={handleFilesSelected} copy={uploadCopy} />
       <QualitySlider value={quality} onChange={setQuality} copy={qualityCopy} />
+      <CompressionStats items={statsItems} copy={compressionStatsCopy} />
       <ImagePreview files={files} onRemove={handleRemove} copy={previewCopy} />
     </div>
   );

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -5,6 +5,11 @@ import { CompressionStats, QualitySlider } from '../compressor';
 import type { CompressionStatsItem } from '@/types';
 import type { UploaderPanelProps } from '@/types';
 
+interface SelectedFileItem {
+  id: string;
+  file: File;
+}
+
 // Heuristic bounds for estimating output size with a normalized quality value.
 const MIN_COMPRESSION_RATIO = 0.35;
 const MAX_COMPRESSION_RATIO = 1;
@@ -23,12 +28,12 @@ export function UploaderPanel({
   qualityCopy,
   compressionStatsCopy,
 }: UploaderPanelProps) {
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<SelectedFileItem[]>([]);
   const [quality, setQuality] = useState<number>(0.8);
 
   const statsItems = useMemo<CompressionStatsItem[]>(() => {
-    return files.map((file, index) => ({
-      id: `${file.name}-${file.lastModified}-${index}`,
+    return files.map(({ id, file }) => ({
+      id,
       filename: file.name,
       originalBytes: file.size,
       compressedBytes: estimateCompressedSize(file.size, quality),
@@ -36,7 +41,13 @@ export function UploaderPanel({
   }, [files, quality]);
 
   const handleFilesSelected = useCallback((incomingFiles: File[]) => {
-    setFiles((previousFiles) => [...previousFiles, ...incomingFiles]);
+    setFiles((previousFiles) => [
+      ...previousFiles,
+      ...incomingFiles.map((file) => ({
+        id: crypto.randomUUID(),
+        file,
+      })),
+    ]);
   }, []);
 
   const handleRemove = useCallback((indexToRemove: number) => {
@@ -50,7 +61,7 @@ export function UploaderPanel({
       <UploadZone onFilesSelected={handleFilesSelected} copy={uploadCopy} />
       <QualitySlider value={quality} onChange={setQuality} copy={qualityCopy} />
       <CompressionStats items={statsItems} copy={compressionStatsCopy} />
-      <ImagePreview files={files} onRemove={handleRemove} copy={previewCopy} />
+      <ImagePreview files={files.map(({ file }) => file)} onRemove={handleRemove} copy={previewCopy} />
     </div>
   );
 }

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -5,9 +5,15 @@ import { CompressionStats, QualitySlider } from '../compressor';
 import type { CompressionStatsItem } from '@/types';
 import type { UploaderPanelProps } from '@/types';
 
+// Heuristic bounds for estimating output size with a normalized quality value.
+const MIN_COMPRESSION_RATIO = 0.35;
+const MAX_COMPRESSION_RATIO = 1;
+
 function estimateCompressedSize(bytes: number, quality: number): number {
   const safeBytes = Math.max(0, bytes);
-  const ratio = 0.35 + (quality * 0.65);
+  const clampedQuality = Math.min(1, Math.max(0, quality));
+  const ratio = MIN_COMPRESSION_RATIO
+    + (MAX_COMPRESSION_RATIO - MIN_COMPRESSION_RATIO) * clampedQuality;
   return Math.round(safeBytes * ratio);
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,6 +55,17 @@
       "title": "Compression quality",
       "description": "Adjust output quality before compressing.",
       "valueLabel": "Quality"
+    },
+    "stats": {
+      "title": "Compression stats",
+      "description": "Estimated comparison between original and compressed size.",
+      "emptyStateLabel": "No compression data to show yet.",
+      "originalLabel": "Original",
+      "compressedLabel": "Compressed",
+      "savingsLabel": "Savings",
+      "percentageLabel": "Reduction",
+      "estimatedLabel": "Estimated",
+      "errorLabel": "Error"
     }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -55,6 +55,17 @@
       "title": "Calidad de compresión",
       "description": "Ajusta la calidad de salida antes de comprimir.",
       "valueLabel": "Calidad"
+    },
+    "stats": {
+      "title": "Estadísticas de compresión",
+      "description": "Comparativa estimada entre tamaño original y comprimido.",
+      "emptyStateLabel": "Aún no hay datos de compresión para mostrar.",
+      "originalLabel": "Original",
+      "compressedLabel": "Comprimido",
+      "savingsLabel": "Ahorro",
+      "percentageLabel": "Reducción",
+      "estimatedLabel": "Estimado",
+      "errorLabel": "Error"
     }
   }
 }

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -88,6 +88,7 @@ const t = translations;
 				client:load
 				uploadCopy={t.upload}
 				qualityCopy={t.compression.quality}
+				compressionStatsCopy={t.compression.stats}
 				previewCopy={t.preview}
 			/>
 		</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -88,6 +88,7 @@ const t = translations;
 				client:load
 				uploadCopy={t.upload}
 				qualityCopy={t.compression.quality}
+				compressionStatsCopy={t.compression.stats}
 				previewCopy={t.preview}
 			/>
 		</section>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,5 +5,8 @@ export type {
 	ImagePreviewProps,
 	QualitySliderCopy,
 	QualitySliderProps,
+	CompressionStatsCopy,
+	CompressionStatsItem,
+	CompressionStatsProps,
 	UploaderPanelProps,
 } from './upload';

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -48,8 +48,34 @@ export interface QualitySliderProps {
   copy?: Partial<QualitySliderCopy>;
 }
 
+export interface CompressionStatsCopy {
+  title: string;
+  description: string;
+  emptyStateLabel: string;
+  originalLabel: string;
+  compressedLabel: string;
+  savingsLabel: string;
+  percentageLabel: string;
+  estimatedLabel: string;
+  errorLabel: string;
+}
+
+export interface CompressionStatsItem {
+  id: string;
+  filename: string;
+  originalBytes: number;
+  compressedBytes: number;
+  hasError?: boolean;
+}
+
+export interface CompressionStatsProps {
+  items: CompressionStatsItem[];
+  copy?: Partial<CompressionStatsCopy>;
+}
+
 export interface UploaderPanelProps {
   uploadCopy?: Partial<UploadZoneCopy>;
   previewCopy?: Partial<ImagePreviewCopy>;
   qualityCopy?: Partial<QualitySliderCopy>;
+  compressionStatsCopy?: Partial<CompressionStatsCopy>;
 }


### PR DESCRIPTION
## 📋 Descripción
Primera implementación de `CompressionStats` para la Fase 2.

## ✅ Incluye
- Componente `src/components/features/compressor/CompressionStats.tsx`
- Tipos dedicados para stats y copy en `src/types/upload.ts`
- Integración en `UploaderPanel`
- Copys i18n en ES/EN
- Integración en páginas `index.astro` y `en/index.astro`
- Cálculos de ahorro absoluto y porcentaje
- Manejo de casos edge (`0`, igual tamaño, crecimiento)

## 🧪 Validación
- `npm run build` ✅
- Console DevTools sin errores ✅
- Render en desktop/móvil ✅

## ℹ️ Notas
- Esta iteración usa métricas **estimadas** en función de calidad seleccionada hasta integrar resultados reales de compresión (#20/#21).

Refs #17