### PR TITLE
feat(compression): add CompressionProgress component (issue #18)

### DIFF
--- a/src/components/features/compressor/CompressionProgress.tsx
+++ b/src/components/features/compressor/CompressionProgress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import type {
   CompressionProgressCopy,
@@ -34,6 +34,8 @@ function getStatusLabel(status: CompressionProgressStatus, copy: CompressionProg
 }
 
 export function CompressionProgress({ progress, status, copy }: CompressionProgressProps) {
+  const statusId = useId();
+
   const resolvedCopy = useMemo<CompressionProgressCopy>(
     () => ({ ...DEFAULT_COPY, ...copy }),
     [copy]
@@ -55,13 +57,20 @@ export function CompressionProgress({ progress, status, copy }: CompressionProgr
             </span>
           </div>
 
-          <p className={`text-sm md:text-base ${STATUS_STYLES[status]}`}>
+          <p
+            id={statusId}
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className={`text-sm md:text-base ${STATUS_STYLES[status]}`}
+          >
             {statusLabel}
           </p>
 
           <div
             role="progressbar"
             aria-label={resolvedCopy.progressLabel}
+            aria-describedby={statusId}
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={normalizedProgress}

--- a/src/components/features/compressor/CompressionProgress.tsx
+++ b/src/components/features/compressor/CompressionProgress.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { Card } from '@/components/ui/Card';
+import type {
+  CompressionProgressCopy,
+  CompressionProgressProps,
+  CompressionProgressStatus,
+} from '@/types';
+
+const DEFAULT_COPY: CompressionProgressCopy = {
+  title: 'Compression progress',
+  idleLabel: 'Waiting to start compression',
+  compressingLabel: 'Compressing images...',
+  doneLabel: 'Compression completed',
+  errorLabel: 'Compression failed',
+  progressLabel: 'Progress',
+};
+
+const STATUS_STYLES: Record<CompressionProgressStatus, string> = {
+  idle: 'text-monokai-fg/80',
+  compressing: 'text-monokai-cyan',
+  done: 'text-monokai-green',
+  error: 'text-monokai-pink',
+};
+
+function clampProgress(progress: number): number {
+  return Math.min(100, Math.max(0, Math.round(progress)));
+}
+
+function getStatusLabel(status: CompressionProgressStatus, copy: CompressionProgressCopy): string {
+  if (status === 'compressing') return copy.compressingLabel;
+  if (status === 'done') return copy.doneLabel;
+  if (status === 'error') return copy.errorLabel;
+  return copy.idleLabel;
+}
+
+export function CompressionProgress({ progress, status, copy }: CompressionProgressProps) {
+  const resolvedCopy = useMemo<CompressionProgressCopy>(
+    () => ({ ...DEFAULT_COPY, ...copy }),
+    [copy]
+  );
+
+  const normalizedProgress = clampProgress(progress);
+  const statusLabel = getStatusLabel(status, resolvedCopy);
+
+  return (
+    <section className="w-full max-w-5xl mx-auto">
+      <Card variant="border" className="border-monokai-yellow/40 bg-monokai-bg/50">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-xl md:text-2xl font-semibold text-monokai-yellow">
+              {resolvedCopy.title}
+            </h3>
+            <span className="text-sm font-semibold text-monokai-yellow">
+              {normalizedProgress}%
+            </span>
+          </div>
+
+          <p className={`text-sm md:text-base ${STATUS_STYLES[status]}`}>
+            {statusLabel}
+          </p>
+
+          <div
+            role="progressbar"
+            aria-label={resolvedCopy.progressLabel}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={normalizedProgress}
+            aria-valuetext={`${normalizedProgress}% - ${statusLabel}`}
+            className="h-3 w-full rounded-full bg-monokai-fg/20 overflow-hidden"
+          >
+            <div
+              className="h-full rounded-full bg-monokai-yellow transition-all duration-300"
+              style={{ width: `${normalizedProgress}%` }}
+            />
+          </div>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/features/compressor/index.ts
+++ b/src/components/features/compressor/index.ts
@@ -1,2 +1,3 @@
 export { QualitySlider } from './QualitySlider';
 export { CompressionStats } from './CompressionStats';
+export { CompressionProgress } from './CompressionProgress';

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ImagePreview } from './ImagePreview';
 import { UploadZone } from './UploadZone';
 import { CompressionProgress, CompressionStats, QualitySlider } from '../compressor';
-import type { CompressionStatsItem } from '@/types';
-import type { CompressionProgressStatus } from '@/types';
-import type { UploaderPanelProps } from '@/types';
+import type {
+  CompressionProgressStatus,
+  CompressionStatsItem,
+  UploaderPanelProps,
+} from '@/types';
 
 interface SelectedFileItem {
   id: string;

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ImagePreview } from './ImagePreview';
 import { UploadZone } from './UploadZone';
-import { CompressionStats, QualitySlider } from '../compressor';
+import { CompressionProgress, CompressionStats, QualitySlider } from '../compressor';
 import type { CompressionStatsItem } from '@/types';
+import type { CompressionProgressStatus } from '@/types';
 import type { UploaderPanelProps } from '@/types';
 
 interface SelectedFileItem {
@@ -27,9 +28,40 @@ export function UploaderPanel({
   previewCopy,
   qualityCopy,
   compressionStatsCopy,
+  compressionProgressCopy,
 }: UploaderPanelProps) {
   const [files, setFiles] = useState<SelectedFileItem[]>([]);
   const [quality, setQuality] = useState<number>(0.8);
+  const [progress, setProgress] = useState<number>(0);
+  const [progressStatus, setProgressStatus] = useState<CompressionProgressStatus>('idle');
+
+  useEffect(() => {
+    if (files.length === 0) {
+      setProgress(0);
+      setProgressStatus('idle');
+      return;
+    }
+
+    setProgress(0);
+    setProgressStatus('compressing');
+
+    const intervalId = window.setInterval(() => {
+      setProgress((current) => {
+        const next = Math.min(100, current + 10);
+
+        if (next >= 100) {
+          window.clearInterval(intervalId);
+          setProgressStatus('done');
+        }
+
+        return next;
+      });
+    }, 180);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [files]);
 
   const statsItems = useMemo<CompressionStatsItem[]>(() => {
     return files.map(({ id, file }) => ({
@@ -60,6 +92,7 @@ export function UploaderPanel({
     <div className="space-y-8">
       <UploadZone onFilesSelected={handleFilesSelected} copy={uploadCopy} />
       <QualitySlider value={quality} onChange={setQuality} copy={qualityCopy} />
+      <CompressionProgress progress={progress} status={progressStatus} copy={compressionProgressCopy} />
       <CompressionStats items={statsItems} copy={compressionStatsCopy} />
       <ImagePreview files={files.map(({ file }) => file)} onRemove={handleRemove} copy={previewCopy} />
     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -66,6 +66,14 @@
       "percentageLabel": "Reduction",
       "estimatedLabel": "Estimated",
       "errorLabel": "Error"
+    },
+    "progress": {
+      "title": "Compression progress",
+      "idleLabel": "Waiting to start compression",
+      "compressingLabel": "Compressing images...",
+      "doneLabel": "Compression completed",
+      "errorLabel": "Compression failed",
+      "progressLabel": "Progress"
     }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -66,6 +66,14 @@
       "percentageLabel": "Reducción",
       "estimatedLabel": "Estimado",
       "errorLabel": "Error"
+    },
+    "progress": {
+      "title": "Progreso de compresión",
+      "idleLabel": "Esperando para iniciar la compresión",
+      "compressingLabel": "Comprimiendo imágenes...",
+      "doneLabel": "Compresión finalizada",
+      "errorLabel": "La compresión falló",
+      "progressLabel": "Progreso"
     }
   }
 }

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -88,6 +88,7 @@ const t = translations;
 				client:load
 				uploadCopy={t.upload}
 				qualityCopy={t.compression.quality}
+				compressionProgressCopy={t.compression.progress}
 				compressionStatsCopy={t.compression.stats}
 				previewCopy={t.preview}
 			/>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -88,6 +88,7 @@ const t = translations;
 				client:load
 				uploadCopy={t.upload}
 				qualityCopy={t.compression.quality}
+				compressionProgressCopy={t.compression.progress}
 				compressionStatsCopy={t.compression.stats}
 				previewCopy={t.preview}
 			/>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,5 +8,8 @@ export type {
 	CompressionStatsCopy,
 	CompressionStatsItem,
 	CompressionStatsProps,
+	CompressionProgressStatus,
+	CompressionProgressCopy,
+	CompressionProgressProps,
 	UploaderPanelProps,
 } from './upload';

--- a/src/types/upload.ts
+++ b/src/types/upload.ts
@@ -73,9 +73,27 @@ export interface CompressionStatsProps {
   copy?: Partial<CompressionStatsCopy>;
 }
 
+export type CompressionProgressStatus = 'idle' | 'compressing' | 'done' | 'error';
+
+export interface CompressionProgressCopy {
+  title: string;
+  idleLabel: string;
+  compressingLabel: string;
+  doneLabel: string;
+  errorLabel: string;
+  progressLabel: string;
+}
+
+export interface CompressionProgressProps {
+  progress: number;
+  status: CompressionProgressStatus;
+  copy?: Partial<CompressionProgressCopy>;
+}
+
 export interface UploaderPanelProps {
   uploadCopy?: Partial<UploadZoneCopy>;
   previewCopy?: Partial<ImagePreviewCopy>;
   qualityCopy?: Partial<QualitySliderCopy>;
   compressionStatsCopy?: Partial<CompressionStatsCopy>;
+  compressionProgressCopy?: Partial<CompressionProgressCopy>;
 }


### PR DESCRIPTION
## 📋 Descripción
Implementación de `CompressionProgress` para Fase 2 con barra accesible y estados de progreso.

## ✅ Cambios
- Nuevo componente `src/components/features/compressor/CompressionProgress.tsx`
- Estados implementados: `idle`, `compressing`, `done`, `error`
- Barra de progreso `0-100` con `role=progressbar` y atributos `aria-*`
- Integración en `UploaderPanel` con progreso en tiempo real (simulado hasta integración con #20/#21)
- Tipos añadidos en `src/types/upload.ts` y reexports en `src/types/index.ts`
- i18n ES/EN agregado en `src/i18n/es.json` y `src/i18n/en.json`
- Wiring en páginas `src/pages/index.astro` y `src/pages/en/index.astro`

## 🧪 Validación
- `npm run build` ✅
- DevTools MCP console sin errores ✅
- Verificación visual de heading + progressbar + aria values ✅

## 🔗 Issue
Refs #18