### PR TITLE
feat(compression): create background compression worker

### DIFF
--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ImagePreview } from './ImagePreview';
 import { UploadZone } from './UploadZone';
 import { CompressionProgress, CompressionStats, QualitySlider } from '../compressor';
+import { useImageCompression } from '@/hooks/useImageCompression';
+import { showError } from '@/lib/toast';
 import type {
-  CompressionProgressStatus,
   CompressionStatsItem,
   UploaderPanelProps,
 } from '@/types';
@@ -34,45 +35,46 @@ export function UploaderPanel({
 }: UploaderPanelProps) {
   const [files, setFiles] = useState<SelectedFileItem[]>([]);
   const [quality, setQuality] = useState<number>(0.8);
-  const [progress, setProgress] = useState<number>(0);
-  const [progressStatus, setProgressStatus] = useState<CompressionProgressStatus>('idle');
+  const {
+    compressMany,
+    error,
+    isCompressing,
+    progress,
+    reset,
+    results,
+    status,
+  } = useImageCompression();
 
   useEffect(() => {
     if (files.length === 0) {
-      setProgress(0);
-      setProgressStatus('idle');
+      reset();
       return;
     }
 
-    setProgress(0);
-    setProgressStatus('compressing');
+    void compressMany(
+      files.map(({ file }) => file),
+      { quality }
+    );
+  }, [compressMany, files, quality, reset]);
 
-    const intervalId = window.setInterval(() => {
-      setProgress((current) => {
-        const next = Math.min(100, current + 10);
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
 
-        if (next >= 100) {
-          window.clearInterval(intervalId);
-          setProgressStatus('done');
-        }
-
-        return next;
-      });
-    }, 180);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [files]);
+    showError(error);
+  }, [error]);
 
   const statsItems = useMemo<CompressionStatsItem[]>(() => {
-    return files.map(({ id, file }) => ({
+    return files.map(({ id, file }, index) => ({
       id,
       filename: file.name,
       originalBytes: file.size,
-      compressedBytes: estimateCompressedSize(file.size, quality),
+      compressedBytes: results[index]?.compressedSize
+        ?? estimateCompressedSize(file.size, quality),
+      hasError: Boolean(results[index]?.error),
     }));
-  }, [files, quality]);
+  }, [files, quality, results]);
 
   const handleFilesSelected = useCallback((incomingFiles: File[]) => {
     setFiles((previousFiles) => [
@@ -92,9 +94,13 @@ export function UploaderPanel({
 
   return (
     <div className="space-y-8">
-      <UploadZone onFilesSelected={handleFilesSelected} copy={uploadCopy} />
+      <UploadZone
+        onFilesSelected={handleFilesSelected}
+        isProcessing={isCompressing}
+        copy={uploadCopy}
+      />
       <QualitySlider value={quality} onChange={setQuality} copy={qualityCopy} />
-      <CompressionProgress progress={progress} status={progressStatus} copy={compressionProgressCopy} />
+      <CompressionProgress progress={progress} status={status} copy={compressionProgressCopy} />
       <CompressionStats items={statsItems} copy={compressionStatsCopy} />
       <ImagePreview files={files.map(({ file }) => file)} onRemove={handleRemove} copy={previewCopy} />
     </div>

--- a/src/components/features/uploader/UploaderPanel.tsx
+++ b/src/components/features/uploader/UploaderPanel.tsx
@@ -43,10 +43,12 @@ export function UploaderPanel({
     reset,
     results,
     status,
+    terminate,
   } = useImageCompression();
 
   useEffect(() => {
     if (files.length === 0) {
+      terminate();
       reset();
       return;
     }
@@ -55,7 +57,7 @@ export function UploaderPanel({
       files.map(({ file }) => file),
       { quality }
     );
-  }, [compressMany, files, quality, reset]);
+  }, [compressMany, files, quality, reset, terminate]);
 
   useEffect(() => {
     if (!error) {

--- a/src/hooks/useImageCompression.test.ts
+++ b/src/hooks/useImageCompression.test.ts
@@ -20,7 +20,7 @@ type WorkerMessageListener = (event: MessageEvent<CompressionWorkerResponse>) =>
 const OriginalWorker = globalThis.Worker;
 
 class MockCompressionWorker {
-  static mode: 'success' | 'error' | 'empty-error' = 'success';
+  static mode: 'success' | 'error' | 'empty-error' | 'hang' = 'success';
   static terminatedCount = 0;
   static constructorCount = 0;
 
@@ -91,6 +91,10 @@ class MockCompressionWorker {
             message: '',
           },
         });
+        return;
+      }
+
+      if (MockCompressionWorker.mode === 'hang') {
         return;
       }
 
@@ -259,6 +263,57 @@ describe('useImageCompression', () => {
     expect(result.current.progress).toBe(0);
     expect(result.current.results).toEqual([]);
     expect(result.current.error).toBeNull();
+  });
+
+  it('clears previous results when starting a new batch', async () => {
+    const { result } = renderHook(() => useImageCompression());
+    const firstFile = new File([new Uint8Array(64)], 'first.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await result.current.compressOne(firstFile, { quality: 0.8 });
+    });
+
+    expect(result.current.results).toHaveLength(1);
+
+    MockCompressionWorker.mode = 'hang';
+    const secondFile = new File([new Uint8Array(64)], 'second.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      void result.current.compressOne(secondFile, { quality: 0.8 });
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('compressing');
+    expect(result.current.results).toEqual([]);
+
+    act(() => {
+      result.current.terminate();
+    });
+  });
+
+  it('settles an in-flight batch when terminate is called', async () => {
+    MockCompressionWorker.mode = 'hang';
+
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(64)], 'pending.jpg', { type: 'image/jpeg' });
+
+    let pendingPromise!: Promise<CompressionResult>;
+
+    await act(async () => {
+      pendingPromise = result.current.compressOne(file, { quality: 0.8 });
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.terminate();
+    });
+
+    const settled = await pendingPromise;
+
+    expect(settled.error).toBe('Compression cancelled.');
+    expect(result.current.status).toBe('idle');
+    expect(result.current.progress).toBe(0);
+    expect(result.current.isCompressing).toBe(false);
   });
 
   it('terminates the worker instance when requested', async () => {

--- a/src/hooks/useImageCompression.test.ts
+++ b/src/hooks/useImageCompression.test.ts
@@ -1,0 +1,278 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  CompressionResult,
+  CompressionWorkerRequest,
+  CompressionWorkerResponse,
+} from '@/types';
+import { useImageCompression } from './useImageCompression';
+
+const { compressionMock } = vi.hoisted(() => ({
+  compressionMock: vi.fn(),
+}));
+
+vi.mock('browser-image-compression', () => ({
+  default: compressionMock,
+}));
+
+type WorkerMessageListener = (event: MessageEvent<CompressionWorkerResponse>) => void;
+
+const OriginalWorker = globalThis.Worker;
+
+class MockCompressionWorker {
+  static mode: 'success' | 'error' | 'empty-error' = 'success';
+  static terminatedCount = 0;
+  static constructorCount = 0;
+
+  private readonly listeners = new Set<WorkerMessageListener>();
+
+  constructor(..._args: unknown[]) {
+    MockCompressionWorker.constructorCount += 1;
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    if (type !== 'message') {
+      return;
+    }
+
+    if (typeof listener === 'function') {
+      this.listeners.add(listener as unknown as WorkerMessageListener);
+      return;
+    }
+
+    this.listeners.add(listener.handleEvent as unknown as WorkerMessageListener);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    if (type !== 'message') {
+      return;
+    }
+
+    if (typeof listener === 'function') {
+      this.listeners.delete(listener as unknown as WorkerMessageListener);
+      return;
+    }
+
+    this.listeners.delete(listener.handleEvent as unknown as WorkerMessageListener);
+  }
+
+  postMessage(message: CompressionWorkerRequest): void {
+    if (message.type !== 'start') {
+      return;
+    }
+
+    const { jobId, file } = message.payload;
+
+    queueMicrotask(() => {
+      this.emit({
+        type: 'progress',
+        payload: {
+          jobId,
+          progress: 145,
+        },
+      });
+
+      if (MockCompressionWorker.mode === 'error') {
+        this.emit({
+          type: 'error',
+          payload: {
+            jobId,
+            message: 'Compression worker failed.',
+          },
+        });
+        return;
+      }
+
+      if (MockCompressionWorker.mode === 'empty-error') {
+        this.emit({
+          type: 'error',
+          payload: {
+            jobId,
+            message: '',
+          },
+        });
+        return;
+      }
+
+      const outputFile = new File([new Uint8Array([1, 2, 3])], `compressed-${file.name}`, {
+        type: file.type,
+      });
+
+      this.emit({
+        type: 'done',
+        payload: {
+          jobId,
+          outputFile,
+          originalSize: file.size,
+          compressedSize: outputFile.size,
+          savingPercent: file.size > 0 ? ((file.size - outputFile.size) / file.size) * 100 : 0,
+        },
+      });
+    });
+  }
+
+  terminate(): void {
+    MockCompressionWorker.terminatedCount += 1;
+  }
+
+  private emit(message: CompressionWorkerResponse): void {
+    const event = { data: message } as MessageEvent<CompressionWorkerResponse>;
+    this.listeners.forEach((listener) => listener(event));
+  }
+}
+
+describe('useImageCompression', () => {
+  beforeEach(() => {
+    MockCompressionWorker.mode = 'success';
+    MockCompressionWorker.terminatedCount = 0;
+    MockCompressionWorker.constructorCount = 0;
+    compressionMock.mockReset();
+
+    compressionMock.mockImplementation(
+      async (
+        file: File,
+        options?: {
+          onProgress?: (progress: number) => void;
+        }
+      ) => {
+        options?.onProgress?.(60);
+        return new File([new Uint8Array([1, 2, 3, 4])], `fallback-${file.name}`, {
+          type: file.type,
+        });
+      }
+    );
+
+    Object.defineProperty(globalThis, 'Worker', {
+      writable: true,
+      configurable: true,
+      value: MockCompressionWorker,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'Worker', {
+      writable: true,
+      configurable: true,
+      value: OriginalWorker,
+    });
+  });
+
+  it('compresses multiple files and updates status/progress', async () => {
+    const { result } = renderHook(() => useImageCompression());
+
+    const files = [
+      new File([new Uint8Array(80)], 'first.jpg', { type: 'image/jpeg' }),
+      new File([new Uint8Array(160)], 'second.jpg', { type: 'image/jpeg' }),
+    ];
+
+    let output: CompressionResult[] = [];
+
+    await act(async () => {
+      output = await result.current.compressMany(files, { quality: 0.7 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('done');
+    });
+
+    expect(output).toHaveLength(2);
+    expect(output[0]?.error).toBeUndefined();
+    expect(output[0]?.outputFile).toBeInstanceOf(File);
+    expect(result.current.isCompressing).toBe(false);
+    expect(result.current.progress).toBe(100);
+    expect(result.current.results).toHaveLength(2);
+    expect(MockCompressionWorker.constructorCount).toBe(1);
+  });
+
+  it('returns failed result and error state when worker fails', async () => {
+    MockCompressionWorker.mode = 'error';
+
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(48)], 'broken.jpg', { type: 'image/jpeg' });
+
+    let output!: CompressionResult;
+
+    await act(async () => {
+      output = await result.current.compressOne(file, { quality: 0.5 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    expect(output.error).toBe('Compression worker failed.');
+    expect(result.current.error).toBe('Compression worker failed.');
+    expect(result.current.progress).toBe(100);
+  });
+
+  it('uses default error message when worker sends empty error text', async () => {
+    MockCompressionWorker.mode = 'empty-error';
+
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(48)], 'empty-error.jpg', { type: 'image/jpeg' });
+
+    let output!: CompressionResult;
+
+    await act(async () => {
+      output = await result.current.compressOne(file, { quality: 0.5 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    expect(output.error).toBe('Compression failed.');
+    expect(result.current.error).toBe('Compression failed.');
+  });
+
+  it('falls back to in-thread compression when Worker is unavailable', async () => {
+    Object.defineProperty(globalThis, 'Worker', {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(120)], 'fallback.jpg', { type: 'image/jpeg' });
+
+    let output!: CompressionResult;
+
+    await act(async () => {
+      output = await result.current.compressOne(file, { quality: 0.9 });
+    });
+
+    expect(compressionMock).toHaveBeenCalledTimes(1);
+    expect(output.error).toBeUndefined();
+    expect(output.outputFile).toBeInstanceOf(File);
+    expect(result.current.status).toBe('done');
+    expect(result.current.progress).toBe(100);
+  });
+
+  it('resets to idle state when compressMany receives an empty array', async () => {
+    const { result } = renderHook(() => useImageCompression());
+
+    await act(async () => {
+      await result.current.compressMany([]);
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.progress).toBe(0);
+    expect(result.current.results).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('terminates the worker instance when requested', async () => {
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(64)], 'sample.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await result.current.compressOne(file, { quality: 0.8 });
+    });
+
+    act(() => {
+      result.current.terminate();
+    });
+
+    expect(MockCompressionWorker.terminatedCount).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useImageCompression.ts
+++ b/src/hooks/useImageCompression.ts
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import imageCompression from 'browser-image-compression';
+import type {
+  CompressionOptions,
+  CompressionResult,
+  CompressionWorkerRequest,
+  CompressionWorkerResponse,
+  UseImageCompressionReturn,
+} from '@/types/compression';
+import type { CompressionProgressStatus } from '@/types';
+
+type CompressionLibraryOptions = Parameters<typeof imageCompression>[1];
+
+type PendingJob = {
+  file: File;
+  batchId: string;
+  resolve: (result: CompressionResult) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const DEFAULT_OPTIONS: CompressionOptions = {
+  quality: 0.8,
+};
+
+function clampProgress(progress: number): number {
+  if (!Number.isFinite(progress)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(progress)));
+}
+
+function createId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getCompressionId(file: File): string {
+  return `${file.name}-${file.lastModified}-${file.size}-${createId()}`;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error;
+  }
+
+  return 'Compression failed.';
+}
+
+function toCompressionOptions(
+  options: CompressionOptions,
+  onProgress: (progress: number) => void
+): CompressionLibraryOptions {
+  return {
+    useWebWorker: false,
+    initialQuality: options.quality,
+    maxWidthOrHeight: options.maxWidthOrHeight,
+    maxSizeMB: options.maxSizeMB,
+    fileType: options.fileType,
+    onProgress,
+  };
+}
+
+function toSuccessfulResult(file: File, outputFile: File): CompressionResult {
+  const originalSize = file.size;
+  const compressedSize = outputFile.size;
+  const savingPercent =
+    originalSize > 0 ? ((originalSize - compressedSize) / originalSize) * 100 : 0;
+
+  return {
+    id: getCompressionId(file),
+    inputFile: file,
+    outputFile,
+    originalSize,
+    compressedSize,
+    savingPercent,
+  };
+}
+
+function toFailedResult(file: File, error: unknown): CompressionResult {
+  return {
+    id: getCompressionId(file),
+    inputFile: file,
+    originalSize: file.size,
+    compressedSize: file.size,
+    savingPercent: 0,
+    error: toErrorMessage(error),
+  };
+}
+
+export function useImageCompression(): UseImageCompressionReturn {
+  const [results, setResults] = useState<CompressionResult[]>([]);
+  const [progress, setProgress] = useState<number>(0);
+  const [isCompressing, setIsCompressing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<CompressionProgressStatus>('idle');
+
+  const workerRef = useRef<Worker | null>(null);
+  const pendingJobsRef = useRef<Map<string, PendingJob>>(new Map());
+  const activeBatchIdRef = useRef<string | null>(null);
+  const batchJobsRef = useRef<Map<string, Set<string>>>(new Map());
+  const jobProgressRef = useRef<Map<string, number>>(new Map());
+
+  const updateBatchProgress = useCallback((batchId: string) => {
+    const batchJobs = batchJobsRef.current.get(batchId);
+    if (!batchJobs || batchJobs.size === 0) {
+      setProgress(0);
+      return;
+    }
+
+    let total = 0;
+    batchJobs.forEach((jobId) => {
+      total += jobProgressRef.current.get(jobId) ?? 0;
+    });
+
+    setProgress(clampProgress(total / batchJobs.size));
+  }, []);
+
+  const clearBatchState = useCallback((batchId: string) => {
+    const batchJobs = batchJobsRef.current.get(batchId);
+    if (!batchJobs) {
+      return;
+    }
+
+    batchJobs.forEach((jobId) => {
+      jobProgressRef.current.delete(jobId);
+      pendingJobsRef.current.delete(jobId);
+    });
+
+    batchJobsRef.current.delete(batchId);
+  }, []);
+
+  const handleWorkerMessage = useCallback(
+    (event: MessageEvent<CompressionWorkerResponse>) => {
+      const message = event.data;
+      if (!message) {
+        return;
+      }
+
+      if (message.type === 'progress') {
+        const { jobId, progress: messageProgress } = message.payload;
+        const job = pendingJobsRef.current.get(jobId);
+        if (!job) {
+          return;
+        }
+
+        jobProgressRef.current.set(jobId, clampProgress(messageProgress));
+
+        if (job.batchId === activeBatchIdRef.current) {
+          updateBatchProgress(job.batchId);
+        }
+
+        return;
+      }
+
+      if (message.type === 'done') {
+        const { jobId, outputFile, originalSize, compressedSize, savingPercent } = message.payload;
+        const job = pendingJobsRef.current.get(jobId);
+        if (!job) {
+          return;
+        }
+
+        pendingJobsRef.current.delete(jobId);
+        jobProgressRef.current.set(jobId, 100);
+
+        const result: CompressionResult = {
+          id: getCompressionId(job.file),
+          inputFile: job.file,
+          outputFile,
+          originalSize,
+          compressedSize,
+          savingPercent,
+        };
+
+        job.resolve(result);
+
+        if (job.batchId === activeBatchIdRef.current) {
+          updateBatchProgress(job.batchId);
+        }
+
+        return;
+      }
+
+      if (message.type === 'error') {
+        const { jobId, message: errorMessage } = message.payload;
+        const job = pendingJobsRef.current.get(jobId);
+        if (!job) {
+          return;
+        }
+
+        pendingJobsRef.current.delete(jobId);
+        jobProgressRef.current.set(jobId, 100);
+        job.reject(new Error(errorMessage));
+
+        if (job.batchId === activeBatchIdRef.current) {
+          updateBatchProgress(job.batchId);
+        }
+      }
+    },
+    [updateBatchProgress]
+  );
+
+  const attachWorker = useCallback((): Worker | null => {
+    if (typeof Worker === 'undefined') {
+      return null;
+    }
+
+    if (workerRef.current) {
+      return workerRef.current;
+    }
+
+    const worker = new Worker(new URL('../workers/compression.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+
+    worker.addEventListener('message', handleWorkerMessage as EventListener);
+    workerRef.current = worker;
+
+    return worker;
+  }, [handleWorkerMessage]);
+
+  const terminate = useCallback(() => {
+    if (workerRef.current) {
+      workerRef.current.removeEventListener('message', handleWorkerMessage as EventListener);
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+
+    pendingJobsRef.current.clear();
+    batchJobsRef.current.clear();
+    jobProgressRef.current.clear();
+    activeBatchIdRef.current = null;
+    setIsCompressing(false);
+  }, [handleWorkerMessage]);
+
+  const reset = useCallback(() => {
+    setResults([]);
+    setProgress(0);
+    setError(null);
+    setStatus('idle');
+  }, []);
+
+  const compressWithFallback = useCallback(
+    async (
+      file: File,
+      options: CompressionOptions,
+      batchId: string,
+      jobId: string
+    ): Promise<CompressionResult> => {
+      const outputFile = await imageCompression(
+        file,
+        toCompressionOptions(options, (currentProgress) => {
+          jobProgressRef.current.set(jobId, clampProgress(currentProgress));
+          if (batchId === activeBatchIdRef.current) {
+            updateBatchProgress(batchId);
+          }
+        })
+      );
+
+      jobProgressRef.current.set(jobId, 100);
+      if (batchId === activeBatchIdRef.current) {
+        updateBatchProgress(batchId);
+      }
+
+      return toSuccessfulResult(file, outputFile);
+    },
+    [updateBatchProgress]
+  );
+
+  const compressFile = useCallback(
+    async (file: File, options: CompressionOptions, batchId: string, index: number) => {
+      const jobId = `${batchId}-${index}-${createId()}`;
+
+      if (!batchJobsRef.current.has(batchId)) {
+        batchJobsRef.current.set(batchId, new Set<string>());
+      }
+
+      batchJobsRef.current.get(batchId)?.add(jobId);
+      jobProgressRef.current.set(jobId, 0);
+
+      const worker = attachWorker();
+      if (!worker) {
+        return compressWithFallback(file, options, batchId, jobId);
+      }
+
+      return new Promise<CompressionResult>((resolve, reject) => {
+        pendingJobsRef.current.set(jobId, {
+          file,
+          batchId,
+          resolve,
+          reject,
+        });
+
+        const message: CompressionWorkerRequest = {
+          type: 'start',
+          payload: {
+            jobId,
+            file,
+            options,
+          },
+        };
+
+        worker.postMessage(message);
+      });
+    },
+    [attachWorker, compressWithFallback]
+  );
+
+  const compressMany = useCallback(
+    async (files: File[], options?: Partial<CompressionOptions>): Promise<CompressionResult[]> => {
+      if (files.length === 0) {
+        reset();
+        return [];
+      }
+
+      const mergedOptions: CompressionOptions = {
+        ...DEFAULT_OPTIONS,
+        ...options,
+      };
+
+      const batchId = createId();
+      activeBatchIdRef.current = batchId;
+      setIsCompressing(true);
+      setProgress(0);
+      setError(null);
+      setStatus('compressing');
+
+      const tasks = files.map(async (file, index) => {
+        try {
+          return await compressFile(file, mergedOptions, batchId, index);
+        } catch (reason) {
+          return toFailedResult(file, reason);
+        }
+      });
+
+      const resolvedResults = await Promise.all(tasks);
+
+      if (activeBatchIdRef.current !== batchId) {
+        return resolvedResults;
+      }
+
+      const firstError = resolvedResults.find((result) => typeof result.error === 'string');
+
+      setResults(resolvedResults);
+      setIsCompressing(false);
+      setProgress(100);
+      setStatus(firstError ? 'error' : 'done');
+      setError(firstError?.error ?? null);
+      clearBatchState(batchId);
+
+      return resolvedResults;
+    },
+    [clearBatchState, compressFile, reset]
+  );
+
+  const compressOne = useCallback(
+    async (file: File, options?: Partial<CompressionOptions>): Promise<CompressionResult> => {
+      const [result] = await compressMany([file], options);
+      return result;
+    },
+    [compressMany]
+  );
+
+  useEffect(() => {
+    return () => {
+      terminate();
+    };
+  }, [terminate]);
+
+  return {
+    compressOne,
+    compressMany,
+    isCompressing,
+    status,
+    progress,
+    error,
+    results,
+    reset,
+    terminate,
+  };
+}

--- a/src/hooks/useImageCompression.ts
+++ b/src/hooks/useImageCompression.ts
@@ -22,6 +22,8 @@ const DEFAULT_OPTIONS: CompressionOptions = {
   quality: 0.8,
 };
 
+const CANCELLED_MESSAGE = 'Compression cancelled.';
+
 function clampProgress(progress: number): number {
   if (!Number.isFinite(progress)) {
     return 0;
@@ -137,6 +139,20 @@ export function useImageCompression(): UseImageCompressionReturn {
     batchJobsRef.current.delete(batchId);
   }, []);
 
+  const cancelPendingJobs = useCallback((reasonMessage: string, batchId?: string) => {
+    const pendingEntries = Array.from(pendingJobsRef.current.entries());
+
+    pendingEntries.forEach(([jobId, pendingJob]) => {
+      if (batchId && pendingJob.batchId !== batchId) {
+        return;
+      }
+
+      pendingJob.reject(new Error(reasonMessage));
+      pendingJobsRef.current.delete(jobId);
+      jobProgressRef.current.delete(jobId);
+    });
+  }, []);
+
   const handleWorkerMessage = useCallback(
     (event: MessageEvent<CompressionWorkerResponse>) => {
       const message = event.data;
@@ -227,18 +243,29 @@ export function useImageCompression(): UseImageCompressionReturn {
   }, [handleWorkerMessage]);
 
   const terminate = useCallback(() => {
+    const activeBatchId = activeBatchIdRef.current;
+    cancelPendingJobs(CANCELLED_MESSAGE);
+
+    if (activeBatchId) {
+      clearBatchState(activeBatchId);
+    }
+
     if (workerRef.current) {
       workerRef.current.removeEventListener('message', handleWorkerMessage as EventListener);
       workerRef.current.terminate();
       workerRef.current = null;
     }
 
+    activeBatchIdRef.current = null;
     pendingJobsRef.current.clear();
     batchJobsRef.current.clear();
     jobProgressRef.current.clear();
-    activeBatchIdRef.current = null;
+    setResults([]);
+    setProgress(0);
+    setError(null);
+    setStatus('idle');
     setIsCompressing(false);
-  }, [handleWorkerMessage]);
+  }, [cancelPendingJobs, clearBatchState, handleWorkerMessage]);
 
   const reset = useCallback(() => {
     setResults([]);
@@ -326,38 +353,48 @@ export function useImageCompression(): UseImageCompressionReturn {
       };
 
       const batchId = createId();
+
+      if (activeBatchIdRef.current) {
+        cancelPendingJobs(CANCELLED_MESSAGE, activeBatchIdRef.current);
+        clearBatchState(activeBatchIdRef.current);
+      }
+
       activeBatchIdRef.current = batchId;
       setIsCompressing(true);
       setProgress(0);
+      setResults([]);
       setError(null);
       setStatus('compressing');
 
-      const tasks = files.map(async (file, index) => {
-        try {
-          return await compressFile(file, mergedOptions, batchId, index);
-        } catch (reason) {
-          return toFailedResult(file, reason);
+      try {
+        const tasks = files.map(async (file, index) => {
+          try {
+            return await compressFile(file, mergedOptions, batchId, index);
+          } catch (reason) {
+            return toFailedResult(file, reason);
+          }
+        });
+
+        const resolvedResults = await Promise.all(tasks);
+
+        if (activeBatchIdRef.current !== batchId) {
+          return resolvedResults;
         }
-      });
 
-      const resolvedResults = await Promise.all(tasks);
+        const firstError = resolvedResults.find((result) => typeof result.error === 'string');
 
-      if (activeBatchIdRef.current !== batchId) {
+        setResults(resolvedResults);
+        setIsCompressing(false);
+        setProgress(100);
+        setStatus(firstError ? 'error' : 'done');
+        setError(firstError?.error ?? null);
+
         return resolvedResults;
+      } finally {
+        clearBatchState(batchId);
       }
-
-      const firstError = resolvedResults.find((result) => typeof result.error === 'string');
-
-      setResults(resolvedResults);
-      setIsCompressing(false);
-      setProgress(100);
-      setStatus(firstError ? 'error' : 'done');
-      setError(firstError?.error ?? null);
-      clearBatchState(batchId);
-
-      return resolvedResults;
     },
-    [clearBatchState, compressFile, reset]
+    [cancelPendingJobs, clearBatchState, compressFile, reset]
   );
 
   const compressOne = useCallback(

--- a/src/types/compression.ts
+++ b/src/types/compression.ts
@@ -1,0 +1,73 @@
+import type { CompressionProgressStatus } from './upload';
+
+export interface CompressionOptions {
+  quality: number;
+  maxWidthOrHeight?: number;
+  maxSizeMB?: number;
+  fileType?: string;
+}
+
+export interface CompressionResult {
+  id: string;
+  inputFile: File;
+  outputFile?: File;
+  originalSize: number;
+  compressedSize: number;
+  savingPercent: number;
+  error?: string;
+}
+
+export interface CompressionWorkerStartMessage {
+  type: 'start';
+  payload: {
+    jobId: string;
+    file: File;
+    options: CompressionOptions;
+  };
+}
+
+export interface CompressionWorkerProgressMessage {
+  type: 'progress';
+  payload: {
+    jobId: string;
+    progress: number;
+  };
+}
+
+export interface CompressionWorkerDoneMessage {
+  type: 'done';
+  payload: {
+    jobId: string;
+    outputFile: File;
+    originalSize: number;
+    compressedSize: number;
+    savingPercent: number;
+  };
+}
+
+export interface CompressionWorkerErrorMessage {
+  type: 'error';
+  payload: {
+    jobId: string;
+    message: string;
+  };
+}
+
+export type CompressionWorkerRequest = CompressionWorkerStartMessage;
+
+export type CompressionWorkerResponse =
+  | CompressionWorkerProgressMessage
+  | CompressionWorkerDoneMessage
+  | CompressionWorkerErrorMessage;
+
+export interface UseImageCompressionReturn {
+  compressOne: (file: File, options?: Partial<CompressionOptions>) => Promise<CompressionResult>;
+  compressMany: (files: File[], options?: Partial<CompressionOptions>) => Promise<CompressionResult[]>;
+  isCompressing: boolean;
+  status: CompressionProgressStatus;
+  progress: number;
+  error: string | null;
+  results: CompressionResult[];
+  reset: () => void;
+  terminate: () => void;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,11 @@ export type {
 	CompressionProgressProps,
 	UploaderPanelProps,
 } from './upload';
+
+export type {
+	CompressionOptions,
+	CompressionResult,
+	CompressionWorkerRequest,
+	CompressionWorkerResponse,
+	UseImageCompressionReturn,
+} from './compression';

--- a/src/workers/compression.worker.ts
+++ b/src/workers/compression.worker.ts
@@ -1,0 +1,92 @@
+import imageCompression from 'browser-image-compression';
+import type {
+  CompressionOptions,
+  CompressionWorkerRequest,
+  CompressionWorkerResponse,
+} from '../types/compression';
+
+type CompressionLibraryOptions = Parameters<typeof imageCompression>[1];
+
+const ctx = self;
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error;
+  }
+
+  return 'Worker compression failed.';
+}
+
+function buildCompressionOptions(
+  options: CompressionOptions,
+  onProgress: (progress: number) => void
+): CompressionLibraryOptions {
+  return {
+    useWebWorker: false,
+    initialQuality: options.quality,
+    maxWidthOrHeight: options.maxWidthOrHeight,
+    maxSizeMB: options.maxSizeMB,
+    fileType: options.fileType,
+    onProgress,
+  };
+}
+
+ctx.onmessage = async (event: MessageEvent<CompressionWorkerRequest>) => {
+  const { data } = event;
+  if (data.type !== 'start') {
+    return;
+  }
+
+  const {
+    payload: { jobId, file, options },
+  } = data;
+
+  try {
+    const outputFile = await imageCompression(
+      file,
+      buildCompressionOptions(options, (progress) => {
+        const message: CompressionWorkerResponse = {
+          type: 'progress',
+          payload: {
+            jobId,
+            progress,
+          },
+        };
+
+        ctx.postMessage(message);
+      })
+    );
+
+    const originalSize = file.size;
+    const compressedSize = outputFile.size;
+    const savingPercent =
+      originalSize > 0 ? ((originalSize - compressedSize) / originalSize) * 100 : 0;
+
+    const doneMessage: CompressionWorkerResponse = {
+      type: 'done',
+      payload: {
+        jobId,
+        outputFile,
+        originalSize,
+        compressedSize,
+        savingPercent,
+      },
+    };
+
+    ctx.postMessage(doneMessage);
+  } catch (error) {
+    const errorMessage: CompressionWorkerResponse = {
+      type: 'error',
+      payload: {
+        jobId,
+        message: toErrorMessage(error),
+      },
+    };
+
+    ctx.postMessage(errorMessage);
+  }
+};


### PR DESCRIPTION
## Resumen
- agrega `src/workers/compression.worker.ts` con protocolo tipado (`start`, `progress`, `done`, `error`)
- implementa `useImageCompression` con lifecycle, `terminate`, fallback sin worker y API `compressOne/compressMany`
- integra el hook en `UploaderPanel` para reemplazar la simulación de progreso por compresión real en segundo plano
- agrega pruebas del hook para éxito, error, fallback y reset

## Validación local
- `npm run typecheck` ✅
- `npm run test:coverage` ✅ (82.71/72/86.95/82.77 en global)
- `npm run build` ✅

## Notas
- La validación con Chrome DevTools MCP no pudo ejecutarse en este entorno por falta del binario de Chrome (`playwright install chrome`), pero se verificó render/flujo básico en navegador automatizado.

Closes #20
