### PR TITLE
fix(compression): validate unsupported format handling

### DIFF
--- a/src/hooks/useImageCompression.test.ts
+++ b/src/hooks/useImageCompression.test.ts
@@ -209,6 +209,25 @@ describe('useImageCompression', () => {
     expect(result.current.progress).toBe(100);
   });
 
+  it('returns unsupported format error without creating a worker', async () => {
+    const { result } = renderHook(() => useImageCompression());
+    const file = new File([new Uint8Array(48)], 'animated.gif', { type: 'image/gif' });
+
+    let output!: CompressionResult;
+
+    await act(async () => {
+      output = await result.current.compressOne(file, { quality: 0.5 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+
+    expect(output.error).toBe('Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.');
+    expect(result.current.error).toBe('Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.');
+    expect(MockCompressionWorker.constructorCount).toBe(0);
+  });
+
   it('uses default error message when worker sends empty error text', async () => {
     MockCompressionWorker.mode = 'empty-error';
 

--- a/src/hooks/useImageCompression.test.ts
+++ b/src/hooks/useImageCompression.test.ts
@@ -5,7 +5,7 @@ import type {
   CompressionWorkerRequest,
   CompressionWorkerResponse,
 } from '@/types';
-import { useImageCompression } from './useImageCompression';
+import { UNSUPPORTED_FORMAT_MESSAGE, useImageCompression } from './useImageCompression';
 
 const { compressionMock } = vi.hoisted(() => ({
   compressionMock: vi.fn(),
@@ -223,8 +223,8 @@ describe('useImageCompression', () => {
       expect(result.current.status).toBe('error');
     });
 
-    expect(output.error).toBe('Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.');
-    expect(result.current.error).toBe('Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.');
+    expect(output.error).toBe(UNSUPPORTED_FORMAT_MESSAGE);
+    expect(result.current.error).toBe(UNSUPPORTED_FORMAT_MESSAGE);
     expect(MockCompressionWorker.constructorCount).toBe(0);
   });
 

--- a/src/hooks/useImageCompression.ts
+++ b/src/hooks/useImageCompression.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import imageCompression from 'browser-image-compression';
+import { DEFAULT_ACCEPTED_FORMATS } from '@/lib/formats';
 import type {
   CompressionOptions,
   CompressionResult,
@@ -23,6 +24,7 @@ const DEFAULT_OPTIONS: CompressionOptions = {
 };
 
 const CANCELLED_MESSAGE = 'Compression cancelled.';
+const UNSUPPORTED_FORMAT_MESSAGE = 'Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.';
 
 function clampProgress(progress: number): number {
   if (!Number.isFinite(progress)) {
@@ -95,6 +97,11 @@ function toFailedResult(file: File, error: unknown): CompressionResult {
     savingPercent: 0,
     error: toErrorMessage(error),
   };
+}
+
+function isSupportedInputFile(file: File): boolean {
+  const normalizedType = file.type.toLowerCase();
+  return DEFAULT_ACCEPTED_FORMATS.some((supportedType) => supportedType === normalizedType);
 }
 
 export function useImageCompression(): UseImageCompressionReturn {
@@ -368,6 +375,10 @@ export function useImageCompression(): UseImageCompressionReturn {
 
       try {
         const tasks = files.map(async (file, index) => {
+          if (!isSupportedInputFile(file)) {
+            return toFailedResult(file, new Error(UNSUPPORTED_FORMAT_MESSAGE));
+          }
+
           try {
             return await compressFile(file, mergedOptions, batchId, index);
           } catch (reason) {

--- a/src/hooks/useImageCompression.ts
+++ b/src/hooks/useImageCompression.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import imageCompression from 'browser-image-compression';
-import { DEFAULT_ACCEPTED_FORMATS } from '@/lib/formats';
+import { DEFAULT_ACCEPTED_FORMATS, DEFAULT_ACCEPTED_FORMATS_LABEL } from '@/lib/formats';
 import type {
   CompressionOptions,
   CompressionResult,
@@ -24,7 +24,7 @@ const DEFAULT_OPTIONS: CompressionOptions = {
 };
 
 const CANCELLED_MESSAGE = 'Compression cancelled.';
-const UNSUPPORTED_FORMAT_MESSAGE = 'Unsupported format. Use JPG/JPEG/JFIF, PNG, or WebP.';
+export const UNSUPPORTED_FORMAT_MESSAGE = `Unsupported format. Use ${DEFAULT_ACCEPTED_FORMATS_LABEL}.`;
 
 function clampProgress(progress: number): number {
   if (!Number.isFinite(progress)) {

--- a/src/lib/formats.test.ts
+++ b/src/lib/formats.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_ACCEPTED_FORMATS,
+  DEFAULT_ACCEPTED_FORMATS_LABEL,
   getDropzoneAcceptMap,
   getFileExtension,
 } from './formats';
@@ -23,5 +24,11 @@ describe('getDropzoneAcceptMap', () => {
     expect(accept['image/jpeg']).toEqual(['.jpg', '.jpeg', '.jfif']);
     expect(accept['image/png']).toEqual(['.png']);
     expect(accept['image/webp']).toEqual(['.webp']);
+  });
+});
+
+describe('DEFAULT_ACCEPTED_FORMATS_LABEL', () => {
+  it('is derived from accepted formats and extensions map', () => {
+    expect(DEFAULT_ACCEPTED_FORMATS_LABEL).toBe('JPG/JPEG/JFIF, PNG, WebP');
   });
 });

--- a/src/lib/formats.ts
+++ b/src/lib/formats.ts
@@ -10,6 +10,33 @@ const ACCEPT_EXTENSIONS_BY_MIME: Record<string, string[]> = {
   'image/webp': ['.webp'],
 };
 
+const EXTENSION_DISPLAY_LABELS: Record<string, string> = {
+  jpg: 'JPG',
+  jpeg: 'JPEG',
+  jfif: 'JFIF',
+  png: 'PNG',
+  webp: 'WebP',
+};
+
+function toDisplayExtensionLabel(extension: string): string {
+  const normalized = extension.replace('.', '').toLowerCase();
+  return EXTENSION_DISPLAY_LABELS[normalized] ?? normalized.toUpperCase();
+}
+
+function toDisplayFormatLabel(mimeType: string): string {
+  const extensions = ACCEPT_EXTENSIONS_BY_MIME[mimeType] ?? [];
+
+  if (extensions.length === 0) {
+    return mimeType;
+  }
+
+  return extensions.map((extension) => toDisplayExtensionLabel(extension)).join('/');
+}
+
+export const DEFAULT_ACCEPTED_FORMATS_LABEL = DEFAULT_ACCEPTED_FORMATS
+  .map((mimeType) => toDisplayFormatLabel(mimeType))
+  .join(', ');
+
 export function getFileExtension(filename: string): string {
   const lastDot = filename.lastIndexOf('.');
   if (lastDot < 0 || lastDot === filename.length - 1) {


### PR DESCRIPTION
## Resumen
- refuerza `useImageCompression` con validación explícita de formatos soportados (JPG/JPEG/JFIF, PNG, WebP)
- devuelve error tipado y consistente cuando llega un archivo no soportado
- añade prueba unitaria para el caso de formato inválido y asegura que no se instancia Worker innecesariamente

## Validación local
- npm run typecheck ✅
- npm run test:coverage ✅
- npm run build ✅

## Nota de entorno
- La verificación de consola con DevTools MCP quedó bloqueada por disponibilidad de backend/página en esta sesión (error de target cerrado y acceso restringido en navegador integrado).

Closes #21
